### PR TITLE
[F-004+R5] Abschluss-Sackgasse, Absicherung und Doku-Nachzug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Diese Punkte wurden nach mehreren Spec-Überarbeitungen entschieden. Wenn ein ä
 3. `docs/specs/F-XXX-name/README.md` — Feature-Intention und Abhängigkeiten
 4. `docs/specs/F-XXX-name/*.md` — Detail-Specs (User Stories, Workflow, Views)
 
-## Implementierungsstand (Stand 2026-07-27, Branch `feature/design-umsetzung`, PR #98)
+## Implementierungsstand (Stand 2026-07-31, PR #117)
 
 Der Design-Prototyp ist umgesetzt. Alle sechs Features sind gebaut; die Reife
 unterscheidet sich noch.
@@ -190,17 +190,21 @@ unterscheidet sich noch.
 Der Timer ist von Hand pausierbar, und die Montage misst ebenfalls. Beides kippt eine
 zuvor bindende MVP-Antwort in `F-005/service.md`.
 
-**Tests:** 175 JVM-Tests (`./gradlew test`) plus vier Migrationstests in `androidTest`
-(`./gradlew connectedDebugAndroidTest`). Keine Compose-UI-Tests — siehe #104.
+**Tests:** 189 JVM-Tests (`./gradlew test`) plus 13 instrumentierte Tests
+(`./gradlew connectedDebugAndroidTest`) — vier Room-Migrationen und neun Compose-UI-Tests.
+Das UI-Test-Harness steht seit #104; die Konventionen und die Animations-Falle stehen in
+`docs/CODING_RULES.md`.
 
 **Emulator:** AVD `boltmind36` (Android 16, arm64). Starten mit
 `emulator -avd boltmind36 -gpu host`, danach `./gradlew installDebug`. Für ein echtes
 Gerät ändert sich nur das Ziel — USB-Debugging genügt, Android 12 oder neuer.
 
-**Offen:** vierzehn Issues in zwei Milestones. **R5** ist Arbeit ohne Entscheidungsbedarf
-(Compose-UI-Tests, Touch-Target-Nachweis, EXIF-Guard, Platzhalter-Bild, Leucht-Ring,
-F-006-README). **R6** sind acht Produktfragen, die eine Antwort brauchen, bevor Code
-entsteht — darunter das Splash-Video und die zwei Timer-Entscheidungen aus #94.
+**Offen:** siebzehn Issues in zwei Milestones. **R5** sind acht Punkte ohne
+Entscheidungsbedarf — darunter die Demontage-Sackgasse nach Feierabend (#121), die
+Glas-Effekt-Abweichungen (#120), die gestauchte Montage-Bedienzeile (#124) und die
+LOC-Grenze des `BrowserViewModel` (#126). **R6** sind neun Produktfragen, die eine Antwort
+brauchen, bevor Code entsteht — darunter das Splash-Video und die zwei Timer-Entscheidungen
+aus #94.
 
 Der Issue-Nachzug ist erledigt: #76–#96 wurden gegen den gebauten Stand geprüft, fünf
 rückwirkende Issues (#99–#103) schließen die Lücken der Kette Spec → Issue → Test für
@@ -301,7 +305,7 @@ Bei Design-Entscheidungen in dieser Reihenfolge abwägen.
 ## Verbotene Patterns
 
 - Business-Logik in Composables
-- ViewModel > 200 LOC (aktuell: Demontage 190, Uebersicht 170, NeuerVorgang 80 — Demontage ist nah am Limit, bei Erweiterung aufteilen)
+- ViewModel > 200 LOC (gemessen: Browser 279, Uebersicht 146, NeuerVorgang 141, Abschluss 69 — `BrowserViewModel` reisst das Limit, weil es alle drei Betriebsarten bedient; offen als #126)
 - Synchrone DB-Calls auf Main-Thread
 - Wildcard-Imports
 - `GlobalScope`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,11 @@ Code                             Erst nach RED. Siehe TDD-Workflow unten.
 Issues via `gh issue list`. Ein Issue ist eine **Vertical Slice**: es geht durch alle Schichten (Datenschicht → ViewModel → UI → Tests) und liefert für sich Nutzerwert. Milestones bündeln Scheiben zu Liefer-Wellen:
 
 ```
-R1: Foto-Modell              Fundament — SchrittFoto, Label, System-Kamera
-R2: Schritt-Browser          F-006 als gemeinsames Modul, freie Navigation
-R3: Montage und Archiv       Montage-Flow, Archiv-Detailansicht
-R4: Zeiterfassung end-to-end F-005 inklusive Consumer
+R0–R4                        Abgeschlossen und geschlossen (Stand 2026-07-27)
+R5: Absicherung              Aufgaben aus #76–#93, die trotz geschlossenem Issue
+                             offen blieben, plus dabei gefundene Defekte
+R6: Offene Entscheidungen    Produktfragen im gebauten Stand — brauchen eine
+                             Antwort, bevor Code entsteht
 ```
 
 **Nicht mehr verwenden:** die früheren Schichten-Milestones `F-XXX-A/B/C` (Datenschicht / ViewModel / UI). Sie sind geschlossen. Eine Datenschicht ohne Oberfläche ist nicht abnehmbar, und die Issues einer Schicht altern gemeinsam, wenn sich die Spec ändert — genau das ist bei den F-004-Issues passiert.
@@ -181,7 +182,7 @@ unterscheidet sich noch.
 | **F-001** Übersicht | ✅ | Tabs, Vorgangsliste mit Dauer im Archiv, Leerzustände, FAB, Auswahl- und Lösch-Sheet. Vier-Stufen-Datumsregel. Archiv-Detailansicht ist der Browser im Modus ARCHIV. |
 | **F-002** Anlage | ✅ | System-Kamera, Pflicht-Auftragsnummer, Beschreibungsfeld, Direktstart in die Demontage. CameraX und `CAMERA`-Permission sind raus. |
 | **F-003** Demontage | ✅ | Browser im Modus DEMONTAGE. Am Emulator durchgeklickt. |
-| **F-004** Montage | ⚠️ gebaut, nicht durchgespielt | Modus MONTAGE plus Abschluss-Screen. Kompiliert und verdrahtet, aber noch nicht mit echten Daten geprüft. |
+| **F-004** Montage | ✅ | Modus MONTAGE plus Abschluss-Screen. Am 2026-07-27 mit gesetzter Datenbank durchgespielt: Wiedereinstieg, Abhaken, Häkchen zurücknehmen, Archivieren. |
 | **F-005** Zeiterfassung | ✅ | `ZeitMessung`, DAO, Service, Timer-Chip. Pausierbar — siehe unten. |
 | **F-006** Schritt-Browser | ✅ | `ui/schrittbrowser/`, zustandslos, drei Betriebsarten. |
 
@@ -189,16 +190,21 @@ unterscheidet sich noch.
 Der Timer ist von Hand pausierbar, und die Montage misst ebenfalls. Beides kippt eine
 zuvor bindende MVP-Antwort in `F-005/service.md`.
 
-**Tests:** 161 JVM-Tests (`./gradlew test`) plus vier Migrationstests in `androidTest`
-(`./gradlew connectedDebugAndroidTest`). Keine Compose-UI-Tests.
+**Tests:** 175 JVM-Tests (`./gradlew test`) plus vier Migrationstests in `androidTest`
+(`./gradlew connectedDebugAndroidTest`). Keine Compose-UI-Tests — siehe #104.
 
 **Emulator:** AVD `boltmind36` (Android 16, arm64). Starten mit
 `emulator -avd boltmind36 -gpu host`, danach `./gradlew installDebug`. Für ein echtes
 Gerät ändert sich nur das Ziel — USB-Debugging genügt, Android 12 oder neuer.
 
-**Offen:** Splash-Video und Original-Stahltextur ließen sich nicht exportieren und sind
-prozedural ersetzt (als TODO markiert). Die Issues #76–#96 sind noch nicht gegen den
-gebauten Stand nachgezogen.
+**Offen:** vierzehn Issues in zwei Milestones. **R5** ist Arbeit ohne Entscheidungsbedarf
+(Compose-UI-Tests, Touch-Target-Nachweis, EXIF-Guard, Platzhalter-Bild, Leucht-Ring,
+F-006-README). **R6** sind acht Produktfragen, die eine Antwort brauchen, bevor Code
+entsteht — darunter das Splash-Video und die zwei Timer-Entscheidungen aus #94.
+
+Der Issue-Nachzug ist erledigt: #76–#96 wurden gegen den gebauten Stand geprüft, fünf
+rückwirkende Issues (#99–#103) schließen die Lücken der Kette Spec → Issue → Test für
+Arbeit, die in PR #98 ohne Issue entstand.
 
 ### Veraltete Doku
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Diese Punkte wurden nach mehreren Spec-Überarbeitungen entschieden. Wenn ein ä
 
 - **Ablageort ist ein Foto-Label, kein eigener Schritt.** Ein Schritt hält N Fotos (`SchrittFoto`), jedes mit den drei kombinierbaren Flags Bauteil / Übersicht / Ablageort, Default Bauteil. `SchrittTyp` ist ersatzlos gestrichen.
 - **Schrittnummer und Fortschritt sind zwei verschiedene Dinge.** „Schritt 12" ist immer die Demontage-Nummer und wird nie umnummeriert — sie ist die Korrelation zum physischen Ablageort. Der Fortschritt heißt getrennt davon „3 von 15 eingebaut". Formulierungen wie „Schritt 5 von 15" vermischen beides und sind verboten.
-- **F-006 besitzt die Schritt-Navigation vollständig** — Thumbnail-Sprung *und* Vor/Zurück. F-001, F-003 und F-004 verweisen darauf, statt eigene Bedienelemente zu spezifizieren. Einen Sprung-Dialog mit Nummerneingabe gibt es nicht.
+- **Der Thumbnail-Sprung gehört F-006, Vor/Zurück dem Consumer** (entschieden am 2026-07-31, vorher lag beides bei F-006). Die drei Betriebsarten haben an derselben Stelle unterschiedliche Bedienelemente — die Demontage hat gar kein Vor/Zurück, die Montage nur „ZURÜCK", das Archiv zwei schlichte Pfeile. Ein einheitliches Vor/Zurück aus F-006 hätte daneben gestanden statt darin. Die Consumer hängen ihre Kreise in den Slot `bedienkreise`. Einen Sprung-Dialog mit Nummerneingabe gibt es nicht.
 - **Horizontales Wischen** im Bildbereich wechselt das **Foto innerhalb des Schritts** (Karussell), nie den Schritt.
 - **Label sind nur in der Demontage änderbar.** F-004 und das Archiv zeigen sie, ändern sie aber nicht.
 - **Abschluss nur über den Abschluss-Screen.** Ist der letzte Schritt abgehakt, erscheint „Zusammenbau abgeschlossen!" mit „Archivieren"-Button. Back führt zum letzten Schritt zurück, **ohne** zu archivieren. Der „Weiter"-Button wird nicht zum Abschlussbutton — Archivieren nimmt den Vorgang aus der aktiven Liste und braucht mit Handschuhen eine Bestätigung.
@@ -199,12 +199,11 @@ Das UI-Test-Harness steht seit #104; die Konventionen und die Animations-Falle s
 `emulator -avd boltmind36 -gpu host`, danach `./gradlew installDebug`. Für ein echtes
 Gerät ändert sich nur das Ziel — USB-Debugging genügt, Android 12 oder neuer.
 
-**Offen:** siebzehn Issues in zwei Milestones. **R5** sind acht Punkte ohne
-Entscheidungsbedarf — darunter die Demontage-Sackgasse nach Feierabend (#121), die
-Glas-Effekt-Abweichungen (#120), die gestauchte Montage-Bedienzeile (#124) und die
-LOC-Grenze des `BrowserViewModel` (#126). **R6** sind neun Produktfragen, die eine Antwort
-brauchen, bevor Code entsteht — darunter das Splash-Video und die zwei Timer-Entscheidungen
-aus #94.
+**Offen:** achtzehn Issues, neun je Milestone. **R5** ist Arbeit ohne Entscheidungsbedarf —
+darunter die Demontage-Sackgasse nach Feierabend (#121), die Glas-Effekt-Abweichungen (#120),
+die gestauchte Montage-Bedienzeile (#124) und die LOC-Grenze des `BrowserViewModel` (#126).
+**R6** sind Produktfragen, die eine Antwort brauchen, bevor Code entsteht — darunter das
+Splash-Video und die zwei Timer-Entscheidungen aus #94.
 
 Der Issue-Nachzug ist erledigt: #76–#96 wurden gegen den gebauten Stand geprüft, fünf
 rückwirkende Issues (#99–#103) schließen die Lücken der Kette Spec → Issue → Test für

--- a/app/src/androidTest/java/com/boltmind/app/ui/FotoPlatzhalterTest.kt
+++ b/app/src/androidTest/java/com/boltmind/app/ui/FotoPlatzhalterTest.kt
@@ -1,0 +1,130 @@
+package com.boltmind.app.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.boltmind.app.R
+import com.boltmind.app.data.model.SchrittFoto
+import com.boltmind.app.ui.schrittbrowser.FotoKarussell
+import com.boltmind.app.ui.theme.BoltMindTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.time.Instant
+
+/**
+ * Belegt die Trennung der beiden Faelle aus F-006.
+ *
+ * `governance.md` verlangt bei einer **fehlenden Datei** ein Platzhalter-Bild
+ * (US-006.8). Ein Schritt **ohne Fotos** (US-006.9) ist etwas voellig anderes --
+ * waehrend der Arbeit der Normalfall. `schritt-ansicht.md` besteht ausdruecklich
+ * auf der Trennung, und genau die wird hier gepruerft: die beiden Zustaende
+ * duerfen nie denselben Text zeigen.
+ *
+ * Getestet wird `FotoKarussell` einzeln, nicht der ganze Browser. Der haelt zwei
+ * Endlos-Animationen, gegen die Compose bis zum Timeout auf Ruhe wartet -- siehe
+ * `docs/CODING_RULES.md`, Abschnitt "Falle: Endlos-Animationen".
+ *
+ * Ausfuehren: ./gradlew connectedDebugAndroidTest
+ */
+@RunWith(AndroidJUnit4::class)
+class FotoPlatzhalterTest {
+
+    @get:Rule
+    val regel = createComposeRule()
+
+    private val kontext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun text(id: Int): String = kontext.getString(id)
+
+    private fun foto(pfad: String) = SchrittFoto(
+        id = 1,
+        schrittId = 1,
+        pfad = pfad,
+        reihenfolge = 0,
+        aufgenommenAm = Instant.EPOCH
+    )
+
+    private fun zeigeKarussell(fotos: List<SchrittFoto>) {
+        regel.setContent {
+            BoltMindTheme {
+                FotoKarussell(
+                    fotos = fotos,
+                    aktuellesFoto = 0,
+                    schrittNummer = 7,
+                    modifier = Modifier.fillMaxSize(),
+                    onFotoGewaehlt = {},
+                    onFotoGetippt = {}
+                )
+            }
+        }
+    }
+
+    @Test
+    fun eineFehlendeDateiZeigtDenPlatzhalter() {
+        // Given: eine Foto-Zeile, deren Datei es nicht gibt -- etwa nach einem
+        // Backup, das die Datenbank mitnahm, aber nicht den Bilderordner
+        val nirgends = File(kontext.filesDir, "photos/gibt_es_nicht.jpg").absolutePath
+
+        // When: das Karussell zeigt sie
+        zeigeKarussell(listOf(foto(nirgends)))
+
+        // Then: der Platzhalter erscheint. Coil laedt asynchron, deshalb warten
+        // statt sofort behaupten.
+        regel.waitUntil(10_000) {
+            regel.onAllNodes(
+                hasContentDescription(text(R.string.browser_foto_fehlt_beschreibung)),
+                useUnmergedTree = true
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun eineLeereDateiGiltEbenfallsAlsFehlend() {
+        // Given: eine 0-Byte-Huelle, wie FotoManager sie vor dem Kamerastart
+        // anlegt. Bleibt sie nach einem Abbruch mitsamt DB-Zeile stehen, ist das
+        // ein kaputtes Foto -- kein fehlendes und kein gueltiges.
+        val huelle = File(kontext.cacheDir, "leer_${System.currentTimeMillis()}.jpg")
+        huelle.parentFile?.mkdirs()
+        huelle.createNewFile()
+
+        // When: das Karussell zeigt sie
+        zeigeKarussell(listOf(foto(huelle.absolutePath)))
+
+        // Then: derselbe Platzhalter
+        regel.waitUntil(10_000) {
+            regel.onAllNodes(
+                hasContentDescription(text(R.string.browser_foto_fehlt_beschreibung)),
+                useUnmergedTree = true
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+        huelle.delete()
+    }
+
+    @Test
+    fun einSchrittOhneFotosZeigtEtwasAnderesAlsEineFehlendeDatei() {
+        // Given/When: gar keine Fotos
+        zeigeKarussell(emptyList())
+
+        // Then: der Leer-Zustand, NICHT der Platzhalter. Wuerden beide Faelle
+        // denselben Text zeigen, koennte der Mechaniker "noch nicht
+        // fotografiert" nicht von "Foto verloren" unterscheiden.
+        regel.onAllNodes(hasText(text(R.string.browser_keine_fotos)), useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+            .let { require(it) { "Der Leer-Zustand fehlt." } }
+
+        val platzhalterDa = regel.onAllNodes(
+            hasContentDescription(text(R.string.browser_foto_fehlt_beschreibung)),
+            useUnmergedTree = true
+        ).fetchSemanticsNodes().isNotEmpty()
+        require(!platzhalterDa) {
+            "Ein Schritt ohne Fotos darf nicht als fehlende Datei erscheinen."
+        }
+    }
+}

--- a/app/src/androidTest/java/com/boltmind/app/ui/MindesthoeheTest.kt
+++ b/app/src/androidTest/java/com/boltmind/app/ui/MindesthoeheTest.kt
@@ -1,0 +1,94 @@
+package com.boltmind.app.ui
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsAtLeast
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.boltmind.app.ui.components.BoltText
+import com.boltmind.app.ui.components.GlasAktion
+import com.boltmind.app.ui.theme.BoltMindDimensions
+import com.boltmind.app.ui.theme.BoltMindTheme
+import com.boltmind.app.ui.theme.BoltTextWeiss
+import com.boltmind.app.ui.theme.BoltTypo
+import com.boltmind.app.ui.theme.GlasRezepte
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Belegt, dass die 56dp-Mindesthoehe aus `governance.md` wirklich greift.
+ *
+ * Der Test existiert, weil das Projekt diesen Fehler schon einmal hatte: der
+ * frueher vorhandene `BoltMindButton` schrieb `modifier.heightIn(min = ...)` --
+ * also das Minimum **hinter** den von aussen uebergebenen Modifier. Size-Modifier
+ * wirken ueber Constraints von aussen nach innen, ein aeusseres `.height(40.dp)`
+ * gewann damit und die Mindesthoehe war wirkungslos. Der Fehler war nur durch
+ * Lesen zu finden, nie durch Ausprobieren.
+ *
+ * Ausfuehren: ./gradlew connectedDebugAndroidTest  (Emulator oder Geraet noetig)
+ */
+@RunWith(AndroidJUnit4::class)
+class MindesthoeheTest {
+
+    @get:Rule
+    val regel = createComposeRule()
+
+    private companion object {
+        const val MARKE = "aktion"
+    }
+
+    private fun zeigeAktion(aeusserer: Modifier) {
+        regel.setContent {
+            BoltMindTheme {
+                GlasAktion(
+                    rezept = GlasRezepte.orangeFlach,
+                    hoehe = BoltMindDimensions.touchTargetMin,
+                    eckRadius = BoltMindDimensions.radiusStandard,
+                    modifier = aeusserer.testTag(MARKE),
+                    onKlick = {}
+                ) {
+                    BoltText("LOS GEHT'S", BoltTypo.aktionSheet, BoltTextWeiss)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun einAeusseresHoehenmassDruecktDieAktionNichtUnterDasMinimum() {
+        // Given/When: der Aufrufer versucht, die Aktion auf 40dp zu zwingen
+        zeigeAktion(Modifier.height(40.dp))
+
+        // Then: die Governance gewinnt
+        regel.onNodeWithTag(MARKE)
+            .assertHeightIsAtLeast(BoltMindDimensions.touchTargetMin)
+    }
+
+    @Test
+    fun ohneAeusseresMassMisstDieAktionGenauDasMinimum() {
+        // Given/When: der Normalfall
+        zeigeAktion(Modifier)
+
+        // Then: keine unerwartete Aufblaehung
+        regel.onNodeWithTag(MARKE)
+            .assertHeightIsEqualTo(BoltMindDimensions.touchTargetMin)
+    }
+
+    @Test
+    fun einAeusseresPaddingSchrumpftDieGlasflaecheNicht() {
+        // Given/When: NeuerVorgangScreen gibt "NEU KNIPSEN" ein Padding mit
+        zeigeAktion(Modifier.padding(10.dp))
+
+        // Then: die Glasflaeche selbst behaelt ihre 56dp, das Padding kommt oben
+        // drauf. Wuerde man das Minimum blosss nach vorne sortieren, laege das
+        // Padding INNERHALB des Minimums und von den 56dp blieben 36 uebrig --
+        // eine Regression, die genau so aussieht wie ein Fix.
+        regel.onNodeWithTag(MARKE)
+            .assertHeightIsEqualTo(BoltMindDimensions.touchTargetMin)
+    }
+}

--- a/app/src/androidTest/java/com/boltmind/app/ui/StartSmokeTest.kt
+++ b/app/src/androidTest/java/com/boltmind/app/ui/StartSmokeTest.kt
@@ -1,0 +1,93 @@
+package com.boltmind.app.ui
+
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.boltmind.app.MainActivity
+import com.boltmind.app.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Der erste Compose-UI-Test des Projekts.
+ *
+ * Sein Zweck ist es, das Harness zu belegen: dass `ui-test-junit4` und
+ * `debugImplementation(ui-test-manifest)` wirklich tragen, dass die App unter
+ * dem Testrunner mit Koin hochkommt und dass der Splash von selbst uebergibt.
+ * Solange das nicht bewiesen ist, ist jede spaetere UI-Behauptung -- etwa "die
+ * Mindesthoehe greift" -- unbelegt.
+ *
+ * **Warum nur Splash und Uebersicht?** Der Schritt-Browser haelt zwei
+ * Endlos-Animationen: den Atem-Puls des aktiven Thumbnails
+ * (`ThumbnailLeiste.kt`) und den pulsierenden Wischhinweis
+ * (`FotoKarussell.kt`). Compose synchronisiert Tests gegen die Animationsuhr
+ * und wartet auf Ruhe -- die tritt dort nie ein, der Test haenge bis zum
+ * Timeout. Ein Test, der den Browser betritt, muss deshalb
+ * `composeTestRule.mainClock.autoAdvance = false` setzen und die Uhr von Hand
+ * vorstellen. Das ist keine Randnotiz, sondern die erste Falle, in die jeder
+ * naechste UI-Test laeuft.
+ *
+ * Konvention: JUnit 4 ueber AndroidJUnitRunner, eine Klasse je zusammenhaengendem
+ * Anliegen -- siehe `docs/CODING_RULES.md`, Abschnitt "Konvention fuer androidTest".
+ *
+ * Ausfuehren: ./gradlew connectedDebugAndroidTest  (Emulator oder Geraet noetig)
+ */
+@RunWith(AndroidJUnit4::class)
+class StartSmokeTest {
+
+    @get:Rule
+    val regel = createAndroidComposeRule<MainActivity>()
+
+    private fun text(id: Int): String = regel.activity.getString(id)
+
+    /** Wartet, bis mindestens ein Knoten mit diesem Text existiert. */
+    private fun warteAufText(wert: String, timeoutMs: Long = 15_000) {
+        regel.waitUntil(timeoutMs) {
+            regel.onAllNodes(hasText(wert), useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun splashUebergibtVonSelbstAnDieUebersicht() {
+        // Given: die App startet auf dem Splash
+        warteAufText(text(R.string.splash_claim))
+
+        // When: der Splash laeuft ab (2,1 s, plus Puffer fuer langsame Geraete)
+        warteAufText(text(R.string.uebersicht_tab_offen))
+
+        // Then: die Uebersicht steht mit beiden Tabs
+        regel.onNodeWithText(text(R.string.uebersicht_tab_offen)).assertExists()
+        regel.onNodeWithText(text(R.string.uebersicht_tab_archiv)).assertExists()
+    }
+
+    @Test
+    fun splashLaesstSichUeberspringen() {
+        // Given: der Splash ist sichtbar
+        warteAufText(text(R.string.splash_claim))
+
+        // When: irgendwo auf die Flaeche getippt wird (US-007.1)
+        regel.onNodeWithText(text(R.string.splash_claim)).performClick()
+
+        // Then: die Uebersicht erscheint, ohne die vollen 2,1 s abzuwarten
+        warteAufText(text(R.string.uebersicht_tab_offen), timeoutMs = 3_000)
+    }
+
+    @Test
+    fun derWechselInsArchivZeigtDenLeerzustand() {
+        // Given: die Uebersicht steht
+        warteAufText(text(R.string.uebersicht_tab_offen))
+
+        // When: auf den Archiv-Tab gewechselt wird
+        regel.onNodeWithText(text(R.string.uebersicht_tab_archiv)).performClick()
+
+        // Then: der Tab bleibt bedienbar und die App lebt noch. Ein
+        // Leerzustandstext wird hier bewusst nicht geprueft -- er haengt am
+        // Datenbestand des Geraets, und dieser Test soll das Harness belegen,
+        // nicht Inhalte.
+        regel.onNodeWithText(text(R.string.uebersicht_tab_offen)).assertExists()
+    }
+}

--- a/app/src/main/java/com/boltmind/app/feature/browser/BrowserScreen.kt
+++ b/app/src/main/java/com/boltmind/app/feature/browser/BrowserScreen.kt
@@ -67,6 +67,7 @@ fun BrowserScreen(
     onZumOffenenSchritt: () -> Unit,
     onEingebaut: () -> Unit,
     onHaekchenAnfragen: () -> Unit,
+    onZumAbschluss: () -> Unit,
     onVorherigerSchritt: () -> Unit,
     onNaechsterSchritt: () -> Unit,
     onFeierabendAnfragen: () -> Unit,
@@ -112,6 +113,7 @@ fun BrowserScreen(
                     onZumOffenenSchritt = onZumOffenenSchritt,
                     onEingebaut = onEingebaut,
                     onHaekchenAnfragen = onHaekchenAnfragen,
+                    onZumAbschluss = onZumAbschluss,
                     onVorherigerSchritt = onVorherigerSchritt,
                     onNaechsterSchritt = onNaechsterSchritt,
                     onFeierabendAnfragen = onFeierabendAnfragen
@@ -334,6 +336,7 @@ private fun Bedienkreise(
     onZumOffenenSchritt: () -> Unit,
     onEingebaut: () -> Unit,
     onHaekchenAnfragen: () -> Unit,
+    onZumAbschluss: () -> Unit,
     onVorherigerSchritt: () -> Unit,
     onNaechsterSchritt: () -> Unit,
     onFeierabendAnfragen: () -> Unit
@@ -434,6 +437,24 @@ private fun Bedienkreise(
                             BoltTypo.rundbuttonLabelKlein,
                             BoltTextLeise
                         )
+                    }
+                    // Ist jedes Teil drin, gibt es keinen offenen Schritt mehr,
+                    // dessen Abhaken den Abschluss-Screen ausloesen koennte.
+                    // Der grosse Kreis bleibt "DRIN", damit das Zuruecknehmen
+                    // erreichbar ist -- der Weg nach vorne kommt zusaetzlich
+                    // daneben (montage.md, US-004.5).
+                    if (uiState.alleEingebaut) {
+                        Rundbutton(
+                            rezept = GlasRezepte.orangeFlach,
+                            durchmesser = BoltMindDimensions.rundbuttonMittel,
+                            onKlick = onZumAbschluss
+                        ) {
+                            BoltText(
+                                stringResource(R.string.montage_zum_abschluss),
+                                BoltTypo.rundbuttonLabelKlein,
+                                BoltTextWeiss
+                            )
+                        }
                     }
                     if (uiState.nichtEingebaut) {
                         Rundbutton(

--- a/app/src/main/java/com/boltmind/app/feature/browser/BrowserUiState.kt
+++ b/app/src/main/java/com/boltmind/app/feature/browser/BrowserUiState.kt
@@ -89,6 +89,21 @@ data class BrowserUiState(
     val amFahrzeugGeblieben: Boolean
         get() = istMontage && aktiverSchritt?.fotos?.none { it.istAblageort } == true
 
+    /**
+     * In der Montage: jedes Teil ist wieder drin, archiviert ist der Vorgang
+     * aber noch nicht.
+     *
+     * In diesem Zustand gibt es keinen offenen Schritt mehr, dessen Abhaken den
+     * Abschluss-Screen ausloesen koennte -- deshalb braucht es hier den eigenen
+     * Weg dorthin (montage.md, US-004.5).
+     *
+     * Eine leere Schrittliste zaehlt ausdruecklich **nicht** dazu: `all {}` ist
+     * auf ihr wahr, ein Abschluss ueber null Teile waere Unsinn.
+     */
+    val alleEingebaut: Boolean
+        get() = istMontage && schritte.isNotEmpty() &&
+            schritte.all { it.schritt.eingebautBeiMontage }
+
 
     val hatFotosImSchritt: Boolean get() = aktiverSchritt?.fotos?.isNotEmpty() == true
 

--- a/app/src/main/java/com/boltmind/app/feature/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/boltmind/app/feature/browser/BrowserViewModel.kt
@@ -51,14 +51,22 @@ class BrowserViewModel(
             repository.beobachteSchritteMitFotos(vorgangId).collect { alle ->
                 val sortiert = if (modus == BrowserModus.MONTAGE) alle.reversed() else alle
                 _uiState.update { s ->
-                    val index = if (s.laedt) startIndex(sortiert) else s.aktiverIndex
-                    s.copy(
+                    val ersteLadung = s.laedt
+                    val index = if (ersteLadung) startIndex(sortiert) else s.aktiverIndex
+                    val neu = s.copy(
                         laedt = false,
                         vorgang = vorgang,
                         schritte = sortiert,
                         aktiverIndex = index.coerceIn(0, (sortiert.size - 1).coerceAtLeast(0)),
                         eingebauteAnzahl = sortiert.count { it.schritt.eingebautBeiMontage }
                     )
+                    // Steigt der Mechaniker in eine bereits vollstaendige Montage
+                    // wieder ein, fuehrt der Weg direkt zum Abschluss -- es gibt
+                    // keinen offenen Schritt mehr, ueber den er dorthin kaeme
+                    // (montage.md, US-004.5). Nur beim ersten Laden: nach der
+                    // Rueckkehr per Back uebernimmt der Knopf "Zum Abschluss",
+                    // sonst liesse sich der Screen nie verlassen.
+                    if (ersteLadung && neu.alleEingebaut) neu.copy(fertig = true) else neu
                 }
                 zeitAktualisieren()
             }
@@ -129,6 +137,12 @@ class BrowserViewModel(
             else onSchrittGewaehlt(naechster)
         }
     }
+
+    /**
+     * Zurueck zum Abschluss-Screen, nachdem der Mechaniker ihn per Back
+     * verlassen hat. Navigiert nur -- archiviert wird ausschliesslich dort.
+     */
+    fun onZumAbschluss() = _uiState.update { it.copy(fertig = true) }
 
     fun onHaekchenZuruecknehmenBestaetigt() {
         val schritt = _uiState.value.aktiverSchritt?.schritt ?: return

--- a/app/src/main/java/com/boltmind/app/feature/splash/SplashScreen.kt
+++ b/app/src/main/java/com/boltmind/app/feature/splash/SplashScreen.kt
@@ -134,9 +134,10 @@ fun SplashScreen(
     ) {
         // TODO: Der Entwurf legt hier eine Videoschleife (assets/splash-loop.mp4,
         //  Deckkraft .85, object-fit:cover, Z. 49). Die Datei liegt nicht vor und
-        //  liess sich nicht exportieren. Bis sie nachgereicht wird, traegt die
-        //  Stahltextur den Grund; der Verlauf darueber ist unveraendert der des
-        //  Entwurfs.
+        //  liess sich nicht exportieren. Bis sie nachgereicht wird, traegt eine
+        //  ruhige einfarbige Flaeche den Grund; der Verlauf darueber ist
+        //  unveraendert der des Entwurfs. Siehe docs/specs/F-007-splash.md,
+        //  Abschnitt "Offene Fragen".
         BoltRuhigerHintergrund()
         Box(Modifier.fillMaxSize().background(SplashSchleier))
 

--- a/app/src/main/java/com/boltmind/app/ui/components/BoltBausteine.kt
+++ b/app/src/main/java/com/boltmind/app/ui/components/BoltBausteine.kt
@@ -144,9 +144,24 @@ fun GlasAktion(
     onKlick: () -> Unit,
     inhalt: @Composable RowScope.() -> Unit
 ) {
+    // Das Governance-Minimum steht bewusst ZWEIMAL.
+    //
+    // Aussen, weil Size-Modifier ueber Constraints von aussen nach innen wirken:
+    // ein `.height(40.dp)` des Aufrufers wuerde ein nur innen stehendes Minimum
+    // wegcoercen. Genau daran ist der frueher hier stehende `BoltMindButton`
+    // gescheitert -- lautlos, denn die Aktion sah weiterhin richtig aus.
+    //
+    // Innen, weil ein `.padding()` des Aufrufers sonst von der Flaeche abginge
+    // statt obendrauf zu kommen. `NeuerVorgangScreen` gibt "NEU KNIPSEN" ein
+    // Padding mit; ohne die innere Zusicherung schrumpfte die Glasflaeche dort
+    // von 56dp auf 36dp -- eine blosse Umsortierung waere also kein Fix, sondern
+    // ein zweiter Fehler.
+    val mindesthoehe = hoehe.coerceAtLeast(BoltMindDimensions.touchTargetMin)
     Row(
-        modifier = modifier
-            .sizeIn(minHeight = hoehe.coerceAtLeast(BoltMindDimensions.touchTargetMin))
+        modifier = Modifier
+            .sizeIn(minHeight = mindesthoehe)
+            .then(modifier)
+            .sizeIn(minHeight = mindesthoehe)
             .boltKlick(aktiv = aktiv, stauchung = stauchung, onKlick = onKlick)
             .glas(rezept, RoundedCornerShape(eckRadius), eckRadius),
         horizontalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/boltmind/app/ui/components/FotoPlatzhalter.kt
+++ b/app/src/main/java/com/boltmind/app/ui/components/FotoPlatzhalter.kt
@@ -1,0 +1,89 @@
+package com.boltmind.app.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.boltmind.app.R
+import com.boltmind.app.ui.theme.BoltHintergrund
+import com.boltmind.app.ui.theme.BoltMindTheme
+import com.boltmind.app.ui.theme.BoltTextSchwaecher
+import com.boltmind.app.ui.theme.BoltTypo
+
+/**
+ * Steht fuer ein Foto, dessen **Datei fehlt** -- etwa nach einem Backup, das die
+ * Datenbank mitgenommen hat, aber nicht den Bilderordner.
+ *
+ * `governance.md`, Abschnitt "Fehlende Dateien", verlangt dafuer ein
+ * Platzhalter-Bild: "Kein Crash, kein leerer Screen." Welches, ist in
+ * `docs/specs/F-004-montage/montage.md` festgelegt -- das App-Icon.
+ *
+ * **Nicht zu verwechseln mit dem Leer-Zustand.** Ein Schritt ohne Fotos
+ * (US-006.9) ist waehrend der Arbeit voellig normal und sieht deshalb anders
+ * aus: gestrichelter Rahmen mit der Schrittnummer. Hier dagegen ist etwas
+ * kaputt, und das soll man sehen. Die beiden Faelle haengen auch an
+ * verschiedenen Schichten -- der Leer-Zustand an einer Zustandsentscheidung,
+ * dieser hier am Ladezustand von Coil. Es gibt keinen Codepfad, auf dem sie sich
+ * vermischen koennen.
+ *
+ * Eine **leere** Datei (0 Byte) zaehlt fuer Coil ebenfalls als Fehler und landet
+ * hier. Das ist richtig so: eine 0-Byte-Huelle ist ein kaputtes Foto, kein
+ * fehlendes.
+ */
+@Composable
+fun FotoPlatzhalter(
+    modifier: Modifier = Modifier,
+    symbolGroesse: Dp = 56.dp,
+    mitBeschriftung: Boolean = true
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(BoltHintergrund),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterVertically)
+    ) {
+        Image(
+            // Das App-Icon aus mipmap, nicht das 512px-Logo aus drawable-nodpi:
+            // nodpi wird ohne Dichteskalierung dekodiert und kostet fuer eine
+            // Thumbnail-Kachel rund ein Megabyte.
+            painter = painterResource(R.mipmap.ic_launcher),
+            contentDescription = null,
+            modifier = Modifier
+                .size(symbolGroesse)
+                .alpha(0.45f)
+        )
+        if (mitBeschriftung) {
+            BoltText(
+                text = stringResource(R.string.browser_foto_fehlt),
+                stil = BoltTypo.vorgangTitel,
+                farbe = BoltTextSchwaecher
+            )
+        }
+    }
+}
+
+@Preview(name = "Fehlende Datei -- gross")
+@Composable
+private fun VorschauGross() {
+    BoltMindTheme { FotoPlatzhalter(Modifier.size(280.dp)) }
+}
+
+@Preview(name = "Fehlende Datei -- Thumbnail")
+@Composable
+private fun VorschauKlein() {
+    BoltMindTheme {
+        FotoPlatzhalter(Modifier.size(54.dp), symbolGroesse = 26.dp, mitBeschriftung = false)
+    }
+}

--- a/app/src/main/java/com/boltmind/app/ui/navigation/BrowserRoute.kt
+++ b/app/src/main/java/com/boltmind/app/ui/navigation/BrowserRoute.kt
@@ -109,6 +109,7 @@ fun BrowserRoute(
                 )
             )
         },
+        onZumAbschluss = viewModel::onZumAbschluss,
         onVorherigerSchritt = viewModel::onVorherigerSchritt,
         onNaechsterSchritt = viewModel::onNaechsterSchritt,
         onFeierabendAnfragen = {

--- a/app/src/main/java/com/boltmind/app/ui/schrittbrowser/FotoKarussell.kt
+++ b/app/src/main/java/com/boltmind/app/ui/schrittbrowser/FotoKarussell.kt
@@ -29,7 +29,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import com.boltmind.app.ui.components.FotoPlatzhalter
+import coil.compose.SubcomposeAsyncImage
 import com.boltmind.app.R
 import com.boltmind.app.data.model.SchrittFoto
 import com.boltmind.app.ui.components.BoltText
@@ -72,6 +75,7 @@ fun FotoKarussell(
         return
     }
 
+    val fehlendBeschreibung = stringResource(R.string.browser_foto_fehlt_beschreibung)
     val pagerZustand = rememberPagerState(
         initialPage = aktuellesFoto.coerceIn(0, fotos.lastIndex),
         pageCount = { fotos.size }
@@ -89,10 +93,20 @@ fun FotoKarussell(
     }
 
     HorizontalPager(state = pagerZustand, modifier = modifier) { seite ->
-        AsyncImage(
+        // SubcomposeAsyncImage statt AsyncImage: dessen `error`-Painter erbt den
+        // contentScale des Erfolgsbildes (hier Crop) und wuerde das quadratische
+        // App-Icon bildschirmfuellend beschneiden. Die Slot-API trennt das.
+        SubcomposeAsyncImage(
             model = File(fotos[seite].pfad),
             contentDescription = stringResource(R.string.browser_foto_beschreibung),
             contentScale = zuschnitt,
+            error = {
+                FotoPlatzhalter(
+                    Modifier.semantics {
+                        contentDescription = fehlendBeschreibung
+                    }
+                )
+            },
             modifier = Modifier
                 .fillMaxSize()
                 .boltKlick(stauchung = 1f, onKlick = onFotoGetippt)

--- a/app/src/main/java/com/boltmind/app/ui/schrittbrowser/SchrittBrowser.kt
+++ b/app/src/main/java/com/boltmind/app/ui/schrittbrowser/SchrittBrowser.kt
@@ -148,14 +148,15 @@ fun SchrittBrowser(
                 )
             }
 
-            // Dekorative Kugel hinter den Aktionskreisen.
+            // Dekorative Kugel hinter den Aktionskreisen. Sie dunkelt den
+            // Bildbereich ab, damit "SITZT!", "ZURUECK" und "RAUS" auch auf
+            // einem hellen Foto lesbar bleiben.
             Box(
                 Modifier
                     .align(Alignment.BottomEnd)
                     .size(BoltMindDimensions.kugelDurchmesser)
-                    .padding(0.dp)
                     .glas(
-                        GlasRezepte.kapsel,
+                        GlasRezepte.kugel,
                         androidx.compose.foundation.shape.CircleShape,
                         BoltMindDimensions.kugelDurchmesser / 2,
                         rund = true

--- a/app/src/main/java/com/boltmind/app/ui/schrittbrowser/ThumbnailLeiste.kt
+++ b/app/src/main/java/com/boltmind/app/ui/schrittbrowser/ThumbnailLeiste.kt
@@ -31,7 +31,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import coil.compose.SubcomposeAsyncImage
+import com.boltmind.app.ui.components.FotoPlatzhalter
 import com.boltmind.app.R
 import com.boltmind.app.data.model.SchrittMitFotos
 import com.boltmind.app.ui.components.BoltText
@@ -132,6 +135,7 @@ private fun Thumbnail(
     val radius = if (aktiv) BoltMindDimensions.radiusThumbAktiv else BoltMindDimensions.radiusStandard
     val erledigt = zeigeErledigt && schritt.schritt.eingebautBeiMontage
     val mehrFotos = schritt.fotos.size > 1
+    val fehlendBeschreibung = stringResource(R.string.browser_foto_fehlt_beschreibung)
 
     // Der aktive Schritt atmet -- im Entwurf ein pulsierender Aussenschein.
     val puls = rememberInfiniteTransition(label = "thumbAtem")
@@ -175,13 +179,28 @@ private fun Thumbnail(
         ) {
             val erstesFoto = schritt.fotos.firstOrNull()
             if (erstesFoto != null) {
-                AsyncImage(
+                // Kachel und App-Icon sind beide quadratisch, hier genuegt der
+                // error-Slot ohne Subcompose-Umweg. Ohne Beschriftung -- auf
+                // 54dp waere Text unlesbar; die contentDescription traegt die
+                // Aussage stattdessen fuer die Sprachausgabe und fuer Tests.
+                SubcomposeAsyncImage(
                     model = File(erstesFoto.pfad),
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
+                    error = {
+                        FotoPlatzhalter(
+                            modifier = Modifier.semantics {
+                                contentDescription = fehlendBeschreibung
+                            },
+                            symbolGroesse = kachel * 0.5f,
+                            mitBeschriftung = false
+                        )
+                    },
                     modifier = Modifier.fillMaxSize()
                 )
             } else {
+                // Schritt ohne Fotos -- ein anderer Fall als eine fehlende
+                // Datei und deshalb bewusst nur eine dunkle Kachel.
                 Box(Modifier.fillMaxSize().background(BoltHintergrund))
             }
             // Abdunklung oben, damit die Nummer lesbar bleibt.

--- a/app/src/main/java/com/boltmind/app/ui/theme/GlasRezepte.kt
+++ b/app/src/main/java/com/boltmind/app/ui/theme/GlasRezepte.kt
@@ -187,6 +187,25 @@ object GlasRezepte {
         randFarbe = BoltWeiss15
     )
 
+    /**
+     * Die dekorative Kugel hinter den Aktionskreisen des Browsers.
+     *
+     * **Randlos, mit eigener Farbe.** Sie trug versehentlich [kapsel], und das
+     * faellt nur in einem Zustand auf: ueber einem Foto dunkelt die Fuellung
+     * sichtbar ab, auf schwarzem Grund aber ist `BoltPanel55` die
+     * Hintergrundfarbe selbst bei 55 % -- unsichtbar. Uebrig blieb der
+     * 15-%-Rand als nackter 296dp-Kreis quer durch Fortschrittsanzeige und
+     * Label-Chips.
+     *
+     * Eine Kuppel hat keine Kante, deshalb `randBreite = 0`. [BoltKugelHell]
+     * war fuer genau diese Flaeche angelegt und bis dahin unbenutzt.
+     */
+    val kugel = GlasRezept.einfarbig(
+        fuellung = BoltKugelHell,
+        randFarbe = androidx.compose.ui.graphics.Color.Transparent,
+        randBreite = 0.dp
+    )
+
     /** Eingabefeld. Ohne Unschaerfe -- im Entwurf hat es keinen backdrop-filter. */
     val eingabe = GlasRezept.einfarbig(
         fuellung = BoltEingabeFlaeche,

--- a/app/src/main/res/values/strings_browser.xml
+++ b/app/src/main/res/values/strings_browser.xml
@@ -4,6 +4,13 @@
 
     <string name="browser_foto_beschreibung">Foto des Schritts</string>
     <string name="browser_keine_fotos">Keine Fotos zu diesem Schritt</string>
+    <!--
+      Zwei verschiedene Faelle, die nie denselben Wortlaut tragen duerfen:
+      "Keine Fotos zu diesem Schritt" ist waehrend der Arbeit normal,
+      "Foto fehlt" heisst, dass eine Datei verschwunden ist (US-006.8).
+    -->
+    <string name="browser_foto_fehlt">Foto fehlt</string>
+    <string name="browser_foto_fehlt_beschreibung">Foto fehlt — Datei nicht gefunden</string>
     <string name="browser_kein_foto">KEIN FOTO</string>
     <string name="browser_foto_zaehler">FOTO %1$d/%2$d</string>
     <string name="browser_wisch_hinweis">← WISCHEN</string>

--- a/app/src/main/res/values/strings_browser_aktionen.xml
+++ b/app/src/main/res/values/strings_browser_aktionen.xml
@@ -17,6 +17,9 @@
     <string name="montage_sitzt">SITZT!</string>
     <string name="montage_drin">DRIN</string>
     <string name="montage_raus">RAUS</string>
+    <!-- Erscheint nur, wenn jedes Teil abgehakt ist. Ohne ihn waere die
+         Rueckkehr vom Abschluss-Screen eine Sackgasse (montage.md, US-004.5). -->
+    <string name="montage_zum_abschluss">ABSCHLUSS</string>
     <string name="montage_fortschritt">%1$d VON %2$d DRIN</string>
 
     <!-- Timer -->

--- a/app/src/test/java/com/boltmind/app/feature/browser/BrowserFotoSteuerungTest.kt
+++ b/app/src/test/java/com/boltmind/app/feature/browser/BrowserFotoSteuerungTest.kt
@@ -1,0 +1,246 @@
+package com.boltmind.app.feature.browser
+
+import com.boltmind.app.data.foto.FotoManager
+import com.boltmind.app.data.model.Schritt
+import com.boltmind.app.data.model.SchrittFoto
+import com.boltmind.app.data.repository.ReparaturRepository
+import com.boltmind.app.service.zeiterfassung.ReferenzTyp
+import com.boltmind.app.service.zeiterfassung.ZeiterfassungService
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import java.time.Instant
+
+/**
+ * Tests fuer die Foto- und Schrittaktionen der Demontage.
+ *
+ * Zwei Regeln aus `docs/specs/governance.md` haben hier ihren Wachposten, und
+ * beide teilen dieselbe Eigenschaft: **ihr Bruch ist im Betrieb unsichtbar.**
+ *
+ * - **EXIF-Stripping.** Faellt es weg, funktioniert die App unveraendert -- nur
+ *   liegen ab dann GPS-Koordinaten und Zeitstempel in jedem Werkstattfoto. Ein
+ *   Datenschutzfehler ohne Symptom.
+ * - **Wiederholen loescht erst nach Erfolg.** Wird die Reihenfolge gedreht,
+ *   merkt das niemand, solange die Kamera liefert. Erst ein Abbruch vernichtet
+ *   dann ein Foto, das der Mechaniker fuer sicher hielt.
+ *
+ * Deshalb pruefen die Tests hier nicht nur *dass* etwas passiert, sondern in
+ * welcher **Reihenfolge**.
+ */
+@DisplayName("BrowserFotoSteuerung")
+class BrowserFotoSteuerungTest {
+
+    private lateinit var repository: ReparaturRepository
+    private lateinit var fotoManager: FotoManager
+    private lateinit var zeiterfassung: ZeiterfassungService
+    private lateinit var steuerung: BrowserFotoSteuerung
+
+    private companion object {
+        const val SCHRITT_ID = 42L
+        const val ALTES_FOTO_ID = 7L
+        const val NEUER_PFAD = "/photos/schritt_neu.jpg"
+        const val ALTER_PFAD = "/photos/schritt_alt.jpg"
+        val T0: Instant = Instant.parse("2026-07-27T08:00:00Z")
+
+        val ALTES_FOTO = SchrittFoto(
+            id = ALTES_FOTO_ID,
+            schrittId = SCHRITT_ID,
+            pfad = ALTER_PFAD,
+            reihenfolge = 3,
+            aufgenommenAm = T0
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        repository = mock {
+            onBlocking { findFoto(ALTES_FOTO_ID) } doReturn ALTES_FOTO
+        }
+        fotoManager = mock()
+        zeiterfassung = mock()
+        steuerung = BrowserFotoSteuerung(repository, fotoManager, zeiterfassung)
+    }
+
+    @Nested
+    @DisplayName("EXIF-Stripping am Produktivpfad")
+    inner class Exif {
+
+        @Test
+        fun `entfernt die Metadaten, bevor das Foto in der Datenbank landet`() = runTest {
+            // When: ein frisch aufgenommenes Foto wird uebernommen
+            steuerung.fotoUebernehmen(SCHRITT_ID, NEUER_PFAD)
+
+            // Then: erst bereinigen, dann persistieren. Andersherum zeigte die
+            // Zeile eine Weile auf eine Datei mit GPS-Daten darin.
+            inOrder(fotoManager, repository) {
+                verify(fotoManager).entferneExifMetadaten(NEUER_PFAD)
+                verify(repository).fotoAnhaengen(SCHRITT_ID, NEUER_PFAD)
+            }
+        }
+
+        @Test
+        fun `entfernt die Metadaten auch beim Ersetzen eines Fotos`() = runTest {
+            // When: "Wiederholen" liefert eine neue Aufnahme
+            steuerung.fotoErsetzen(ALTES_FOTO_ID, NEUER_PFAD)
+
+            // Then: der Ersetzen-Pfad ist kein Schleichweg an der Regel vorbei
+            inOrder(fotoManager, repository) {
+                verify(fotoManager).entferneExifMetadaten(NEUER_PFAD)
+                verify(repository).fotoErsetzen(ALTES_FOTO_ID, NEUER_PFAD)
+            }
+        }
+
+        @Test
+        fun `fasst das alte Foto beim Ersetzen nicht als zu bereinigen an`() = runTest {
+            // When: ersetzen
+            steuerung.fotoErsetzen(ALTES_FOTO_ID, NEUER_PFAD)
+
+            // Then: bereinigt wird nur die neue Datei. Die alte wurde bei ihrer
+            // eigenen Uebernahme schon bereinigt und verschwindet gleich.
+            verify(fotoManager, never()).entferneExifMetadaten(ALTER_PFAD)
+        }
+    }
+
+    @Nested
+    @DisplayName("Wiederholen loescht erst nach Erfolg")
+    inner class Wiederholen {
+
+        @Test
+        fun `schreibt die neue Zeile, bevor die alte Datei verschwindet`() = runTest {
+            // When: ein Foto wird ersetzt
+            steuerung.fotoErsetzen(ALTES_FOTO_ID, NEUER_PFAD)
+
+            // Then: die Reihenfolge ist die Regel. Bricht irgendetwas dazwischen
+            // ab, ist im schlimmsten Fall eine Datei zu viel da -- nie eine zu
+            // wenig (governance.md, "Wiederholen loescht erst nach Erfolg").
+            inOrder(repository, fotoManager) {
+                verify(repository).fotoErsetzen(ALTES_FOTO_ID, NEUER_PFAD)
+                verify(fotoManager).loescheFoto(ALTER_PFAD)
+            }
+        }
+
+        @Test
+        fun `laesst alles stehen, wenn das zu ersetzende Foto nicht mehr existiert`() = runTest {
+            // Given: die Zeile ist zwischenzeitlich verschwunden
+            repository.stub { onBlocking { findFoto(ALTES_FOTO_ID) } doReturn null }
+
+            // When: ersetzen
+            steuerung.fotoErsetzen(ALTES_FOTO_ID, NEUER_PFAD)
+
+            // Then: nichts geschrieben, nichts geloescht
+            verify(repository, never()).fotoErsetzen(any(), any())
+            verify(fotoManager, never()).loescheFoto(any())
+        }
+    }
+
+    @Nested
+    @DisplayName("Naechstes Teil")
+    inner class NaechstesTeil {
+
+        private val neuerSchritt = Schritt(
+            id = 99L,
+            reparaturvorgangId = 1L,
+            schrittNummer = 5,
+            gestartetAm = T0
+        )
+
+        @Test
+        fun `schliesst den offenen Schritt ab und startet die Messung des neuen`() = runTest {
+            // Given: Schritt 4 ist offen
+            val offen = Schritt(
+                id = SCHRITT_ID,
+                reparaturvorgangId = 1L,
+                schrittNummer = 4,
+                gestartetAm = T0
+            )
+            repository.stub { onBlocking { schrittAnlegen(1L) } doReturn neuerSchritt }
+
+            // When: "Naechstes Teil"
+            steuerung.naechstesTeil(1L, offen)
+
+            // Then: alter Schritt zu, alte Messung gestoppt, neue gestartet
+            inOrder(repository, zeiterfassung) {
+                verify(repository).schrittAbschliessen(SCHRITT_ID)
+                verify(zeiterfassung).stoppeFallsLaeuft(SCHRITT_ID, ReferenzTyp.DEMONTAGE_SCHRITT)
+                verify(repository).schrittAnlegen(1L)
+                verify(zeiterfassung).starten(99L, ReferenzTyp.DEMONTAGE_SCHRITT)
+            }
+        }
+
+        @Test
+        fun `kommt ohne offenen Schritt aus`() = runTest {
+            // Given: der allererste Schritt eines Vorgangs
+            repository.stub { onBlocking { schrittAnlegen(1L) } doReturn neuerSchritt }
+
+            // When: "Naechstes Teil" ohne Vorgaenger
+            steuerung.naechstesTeil(1L, null)
+
+            // Then: nichts abzuschliessen, aber die Messung laeuft an
+            verify(repository, never()).schrittAbschliessen(any())
+            verify(zeiterfassung).starten(99L, ReferenzTyp.DEMONTAGE_SCHRITT)
+        }
+    }
+
+    @Nested
+    @DisplayName("Beenden")
+    inner class Beenden {
+
+        private val offen = Schritt(
+            id = SCHRITT_ID,
+            reparaturvorgangId = 1L,
+            schrittNummer = 4,
+            gestartetAm = T0
+        )
+
+        @Test
+        fun `verwirft einen Schritt ohne Fotos, statt ihn abzuschliessen`() = runTest {
+            // Given: der offene Schritt hat kein einziges Foto
+            repository.stub { onBlocking { holeFotos(SCHRITT_ID) } doReturn emptyList() }
+
+            // When: "Feierabend"
+            steuerung.beenden(offen)
+
+            // Then: geloescht -- sonst bliebe ein leeres Thumbnail zurueck und
+            // die Schrittnummer waere verbrannt, obwohl sie vielleicht schon auf
+            // einem Etikett klebt
+            verify(repository).schrittVerwerfen(SCHRITT_ID)
+            verify(repository, never()).schrittAbschliessen(any())
+        }
+
+        @Test
+        fun `schliesst einen Schritt mit Fotos regulaer ab`() = runTest {
+            // Given: der offene Schritt hat ein Foto
+            repository.stub {
+                onBlocking { holeFotos(SCHRITT_ID) } doReturn listOf(ALTES_FOTO)
+            }
+
+            // When: "Feierabend"
+            steuerung.beenden(offen)
+
+            // Then: abgeschlossen, nicht verworfen
+            verify(repository).schrittAbschliessen(SCHRITT_ID)
+            verify(repository, never()).schrittVerwerfen(any())
+        }
+
+        @Test
+        fun `stoppt die Messung auch dann, wenn der Schritt verworfen wird`() = runTest {
+            // Given: leerer offener Schritt
+            repository.stub { onBlocking { holeFotos(SCHRITT_ID) } doReturn emptyList() }
+
+            // When: "Feierabend"
+            steuerung.beenden(offen)
+
+            // Then: keine Messung bleibt offen zurueck
+            verify(zeiterfassung).stoppeFallsLaeuft(SCHRITT_ID, ReferenzTyp.DEMONTAGE_SCHRITT)
+        }
+    }
+}

--- a/app/src/test/java/com/boltmind/app/feature/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/boltmind/app/feature/browser/BrowserViewModelTest.kt
@@ -504,6 +504,122 @@ class BrowserViewModelTest {
     }
 
     // ------------------------------------------------------------------
+    // Der Abschluss darf nie unerreichbar werden
+    // ------------------------------------------------------------------
+
+    /**
+     * Ist jedes Teil abgehakt, gibt es keinen offenen Schritt mehr, dessen
+     * Abhaken den Abschluss-Screen ausloesen koennte. Ohne die beiden Wege hier
+     * -- Sprung beim Wiedereinstieg und ein eigener Knopf nach der Rueckkehr --
+     * laesst sich der Vorgang nie archivieren und bleibt fuer immer in der
+     * offenen Liste stehen.
+     *
+     * Spec: docs/specs/F-004-montage/montage.md, US-004.5
+     */
+    @Nested
+    inner class `US-004_5 Abschluss erreichbar halten` {
+
+        @Test
+        fun `springt beim Wiedereinstieg sofort zum Abschluss, wenn schon alles drin ist`() {
+            // Given/When: der Mechaniker hat den Abschluss-Screen ohne "AB INS
+            // ARCHIV" verlassen und waehlt spaeter erneut "MONTAGE STARTEN"
+            val browser = browserFuer(
+                BrowserModus.MONTAGE,
+                listOf(schritt(1, eingebaut = true), schritt(2, eingebaut = true))
+            )
+
+            // Then: direkt der Abschluss-Screen, ohne Schreibvorgang
+            assertTrue(browser.uiState.value.fertig)
+            verifyBlocking(repository, never()) { setzeEingebaut(any(), any()) }
+        }
+
+        @Test
+        fun `bleibt still, solange noch ein Teil fehlt`() {
+            // Given/When: ein Teil ist noch nicht eingebaut
+            val browser = browserFuer(
+                BrowserModus.MONTAGE,
+                listOf(schritt(1, eingebaut = true), schritt(2))
+            )
+
+            // Then: kein Sprung -- es gibt noch Arbeit
+            assertFalse(browser.uiState.value.fertig)
+            assertFalse(browser.uiState.value.alleEingebaut)
+        }
+
+        @Test
+        fun `haelt einen Vorgang ohne Schritte nicht faelschlich fuer fertig`() {
+            // Given/When: ein Vorgang, in dem nie demontiert wurde
+            val browser = browserFuer(BrowserModus.MONTAGE, emptyList())
+
+            // Then: eine leere Liste ist nicht "alles eingebaut" -- sonst
+            // schickt der Wiedereinstieg den Mechaniker auf einen Abschluss-
+            // Screen ueber null Teile
+            assertFalse(browser.uiState.value.fertig)
+            assertFalse(browser.uiState.value.alleEingebaut)
+        }
+
+        @Test
+        fun `bietet nach der Rueckkehr vom Abschluss einen Weg dorthin zurueck`() {
+            // Given: der Sprung beim Wiedereinstieg ist quittiert -- der
+            // Mechaniker steht mit Back wieder in der Schritt-Ansicht
+            val browser = browserFuer(
+                BrowserModus.MONTAGE,
+                listOf(schritt(1, eingebaut = true), schritt(2, eingebaut = true))
+            )
+            browser.onNavigationAbgeschlossen()
+            assertFalse(browser.uiState.value.fertig)
+
+            // Then: der Knopf "Zum Abschluss" steht bereit
+            assertTrue(browser.uiState.value.alleEingebaut)
+
+            // When: er wird getippt
+            browser.onZumAbschluss()
+            abarbeiten()
+
+            // Then: wieder zum Abschluss-Screen, ohne etwas zu schreiben
+            assertTrue(browser.uiState.value.fertig)
+            verifyBlocking(repository, never()) { setzeEingebaut(any(), any()) }
+        }
+
+        @Test
+        fun `nimmt den Knopf weg, sobald ein Haekchen zurueckgenommen wurde`() {
+            // Given: alles ist abgehakt und der Knopf steht
+            val browser = browserFuer(
+                BrowserModus.MONTAGE,
+                listOf(schritt(1, eingebaut = true), schritt(2, eingebaut = true))
+            )
+            browser.onNavigationAbgeschlossen()
+            assertTrue(browser.uiState.value.alleEingebaut)
+
+            // When: der Mechaniker nimmt eine Markierung zurueck
+            schritteFlow.value = listOf(schritt(1, eingebaut = true), schritt(2))
+            abarbeiten()
+
+            // Then: wieder ein offenes Teil, der Knopf verschwindet
+            assertFalse(browser.uiState.value.alleEingebaut)
+        }
+
+        @Test
+        fun `kennt den Knopf nur in der Montage`() {
+            // Given/When: dieselbe Datenlage in Demontage und Archiv
+            val demontage = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1, eingebaut = true), schritt(2, eingebaut = true))
+            )
+            val archiv = browserFuer(
+                BrowserModus.ARCHIV,
+                listOf(schritt(1, eingebaut = true), schritt(2, eingebaut = true))
+            )
+
+            // Then: "Zum Abschluss" ist eine Montage-Aktion
+            assertFalse(demontage.uiState.value.alleEingebaut)
+            assertFalse(demontage.uiState.value.fertig)
+            assertFalse(archiv.uiState.value.alleEingebaut)
+            assertFalse(archiv.uiState.value.fertig)
+        }
+    }
+
+    // ------------------------------------------------------------------
     // Kamera (K-02)
     // ------------------------------------------------------------------
 

--- a/app/src/test/java/com/boltmind/app/feature/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/boltmind/app/feature/browser/BrowserViewModelTest.kt
@@ -582,6 +582,33 @@ class BrowserViewModelTest {
         }
 
         @Test
+        fun `schickt nach der Rueckkehr nicht bei jeder Datenmeldung erneut zum Abschluss`() {
+            // Given: der Mechaniker hat den Abschluss-Screen mit Back verlassen
+            val browser = browserFuer(
+                BrowserModus.MONTAGE,
+                listOf(schritt(1, eingebaut = true), schritt(2, eingebaut = true))
+            )
+            browser.onNavigationAbgeschlossen()
+            assertFalse(browser.uiState.value.fertig)
+
+            // When: der Flow meldet die weiterhin vollstaendige Liste erneut.
+            // Room stoesst ihn bei jeder Aenderung an den Schritt-Tabellen an --
+            // was sich dabei aendert, ist gleichgueltig, hier ein Foto
+            schritteFlow.value = listOf(
+                schritt(1, eingebaut = true, fotos = listOf(foto(1))),
+                schritt(2, eingebaut = true)
+            )
+            abarbeiten()
+
+            // Then: er bleibt in der Schritt-Ansicht. Griffe der Sprung nicht nur
+            // beim ersten Laden, waere der Abschluss-Screen eine Falle: Back
+            // wuerde ihn verlassen und die naechste Meldung ihn sofort
+            // zurueckwerfen
+            assertFalse(browser.uiState.value.fertig)
+            assertTrue(browser.uiState.value.alleEingebaut)
+        }
+
+        @Test
         fun `nimmt den Knopf weg, sobald ein Haekchen zurueckgenommen wurde`() {
             // Given: alles ist abgehakt und der Knopf steht
             val browser = browserFuer(

--- a/app/src/test/java/com/boltmind/app/ui/theme/DimensionenTest.kt
+++ b/app/src/test/java/com/boltmind/app/ui/theme/DimensionenTest.kt
@@ -1,0 +1,78 @@
+package com.boltmind.app.ui.theme
+
+import androidx.compose.ui.unit.dp
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Wacht ueber die Masse, die `docs/specs/governance.md` verbindlich festlegt.
+ *
+ * Diese Zahlen sind keine Design-Vorliebe, sondern eine Anforderung aus dem
+ * ersten Quality Goal: bedienbar mit Handschuhen und oeligen Haenden. Ein
+ * spaeterer Tweak auf 48dp soll den Build brechen und nicht stillschweigend
+ * durchgehen -- der Verstoss faellt sonst erst in der Werkstatt auf.
+ *
+ * **Was dieser Test NICHT leistet:** Er belegt die Token-Werte, nicht ihre
+ * Verwendung. Ein literales `.height(40.dp)` an einer Aufrufstelle passiert ihn
+ * ungeruehrt. Diese Luecke schliesst nur `MindesthoeheTest` in `androidTest`.
+ */
+@DisplayName("Governance-Masse")
+class DimensionenTest {
+
+    @Nested
+    @DisplayName("Touch-Targets")
+    inner class TouchTargets {
+
+        @Test
+        fun `primaere Aktionen sind mindestens 56dp hoch`() {
+            assertEquals(
+                56.dp,
+                BoltMindDimensions.touchTargetMin,
+                "governance.md, Abschnitt \"Bedienbarkeit\": 56dp ist das Minimum, " +
+                    "nicht ein Richtwert. Wer das senken will, aendert zuerst die Spec."
+            )
+        }
+
+        @Test
+        fun `benachbarte Touch-Targets stehen mindestens 8dp auseinander`() {
+            assertEquals(
+                8.dp,
+                BoltMindDimensions.touchAbstandMin,
+                "governance.md, Abschnitt \"Bedienbarkeit\": ohne Abstand trifft ein " +
+                    "Handschuh zwei Knoepfe gleichzeitig."
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("Rundbuttons erfuellen das Minimum aus sich heraus")
+    inner class Rundbuttons {
+
+        /**
+         * `Rundbutton` setzt `.size(durchmesser)` -- eine feste Groesse, kein
+         * Minimum. Die Regel wird dort also nicht erzwungen, sondern durch die
+         * Wahl der Token eingehalten. Genau deshalb gehoeren die Token hierher:
+         * ein zu kleiner Wert waere sonst unbemerkt.
+         */
+        @Test
+        fun `kein Rundbutton-Durchmesser liegt unter dem Minimum`() {
+            val durchmesser = mapOf(
+                "rundbuttonKlein" to BoltMindDimensions.rundbuttonKlein,
+                "rundbuttonMittel" to BoltMindDimensions.rundbuttonMittel,
+                "rundbuttonGross" to BoltMindDimensions.rundbuttonGross,
+                "rundbuttonArchivZurueck" to BoltMindDimensions.rundbuttonArchivZurueck,
+                "rundbuttonArchivWeiter" to BoltMindDimensions.rundbuttonArchivWeiter
+            )
+            durchmesser.forEach { (name, wert) ->
+                assertTrue(
+                    wert >= BoltMindDimensions.touchTargetMin,
+                    "$name ist $wert und damit kleiner als das Governance-Minimum " +
+                        "${BoltMindDimensions.touchTargetMin}."
+                )
+            }
+        }
+    }
+}

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -221,14 +221,21 @@ app/src/
 │   ├── feature/
 │   │   ├── FormatierungTest.kt               # Datums- und Zeitformate
 │   │   ├── abschluss/AbschlussViewModelTest.kt
-│   │   └── browser/BrowserViewModelTest.kt   # F-003, F-004 und F-001-Archiv
+│   │   ├── browser/BrowserViewModelTest.kt   # F-003, F-004 und F-001-Archiv
+│   │   └── browser/BrowserFotoSteuerungTest.kt  # Kamera-Abbruch, Wiederholen
 │   ├── data/
 │   │   ├── foto/FotoManagerTest.kt
 │   │   └── repository/ReparaturRepositoryTest.kt
 │   ├── service/zeiterfassung/ZeiterfassungServiceTest.kt
-│   └── ui/components/DebounceClickTest.kt
+│   └── ui/
+│       ├── components/DebounceClickTest.kt
+│       └── theme/DimensionenTest.kt          # Touch-Target-Mindestmasse
 └── androidTest/java/com/boltmind/app/        # Geraet/Emulator, JUnit 4
-    └── data/local/MigrationTest.kt           # Room-Migrationen
+    ├── data/local/MigrationTest.kt           # Room-Migrationen
+    └── ui/
+        ├── StartSmokeTest.kt                 # Start, Splash, Tabwechsel
+        ├── MindesthoeheTest.kt               # GlasAktion haelt 56dp
+        └── FotoPlatzhalterTest.kt            # Platzhalter bei fehlender Datei
 ```
 
 Ein einziger `BrowserViewModelTest` deckt Demontage, Montage und Archiv ab, weil ein einziges
@@ -515,20 +522,23 @@ vorgeschrieben werden:
 | Task | Zweck |
 |------|-------|
 | `./gradlew test` | Unit Tests (JVM, JUnit 5) — der verbindliche Check jedes TDD-Schritts |
-| `./gradlew connectedDebugAndroidTest` | Instrumentierte Tests (Room-Migrationen). Braucht Gerät oder Emulator |
+| `./gradlew connectedDebugAndroidTest` | Instrumentierte Tests (Room-Migrationen und Compose-UI). Braucht Gerät oder Emulator |
 | `./gradlew lint` | Android Lint |
 | `./gradlew assembleDebug` | Debug-Build |
 
-### Werkzeug-Lücken (Stand 2026-07-27)
+### Werkzeug-Lücken (Stand 2026-07-31)
 
-Formatierung, statische Analyse und Compose-UI-Tests sind **gewollt, aber nicht eingerichtet**.
+Formatierung und statische Analyse sind **gewollt, aber nicht eingerichtet**.
 Die folgende Tabelle beschreibt ein Soll, keinen Ist-Zustand:
 
 | Werkzeug | Soll | Ist |
 |----------|------|-----|
 | ktlint | Automatische Formatierung nach Kotlin Coding Conventions, `./gradlew ktlintCheck` / `ktlintFormat` | **Nicht eingerichtet.** Kein ktlint-Plugin in `build.gradle.kts` oder `gradle/libs.versions.toml`; die Tasks existieren nicht. |
 | detekt | Statische Code-Analyse (Complexity, Code Smells, Style), `./gradlew detekt`, Konfiguration in `config/detekt/detekt.yml` | **Nicht eingerichtet.** Kein detekt-Plugin, kein `config/`-Verzeichnis; die Task existiert nicht. |
-Compose-UI-Tests sind **eingerichtet und belegt** (siehe unten) und deshalb keine Lücke mehr.
+
+Compose-UI-Tests waren früher ebenfalls eine Lücke. Sie sind es **nicht mehr**: der
+androidTest-Zweig läuft, die Konventionen stehen im Abschnitt „Konvention für `androidTest`",
+und die Animations-Falle ist gleich darunter beschrieben.
 
 Bis zur Einrichtung ist **keiner dieser Punkte eine Anforderung**: Er darf in keinem TDD-Zyklus als
 Pflichtschritt stehen, kein PR darf an ihm scheitern, und keine Zusammenfassung darf behaupten, der

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -136,6 +136,22 @@ class DemontageViewModel(private val repository: ReparaturRepository) : ViewMode
 | State | Feature + UiState | `DemontageUiState` |
 | Package | lowercase, Feature-Name | `feature.demontage` |
 
+### String-Ressourcen
+
+Ein Key trägt **eine** Bedeutung. Zwei Regeln folgen daraus:
+
+- **Keys der Schritt-Navigation (F-006) tragen das Präfix `browser_`** — `browser_zurueck`,
+  `browser_weiter`, `browser_naechstes`. Sie gehören dem Inhaltsbereich.
+- **Screen-Chrome vergibt die Beschriftung „Zurück" nie.** Der Ausstieg aus einem Screen läuft über
+  die Android-Zurück-Geste und den Zurück-Pfeil in der TopBar; dessen contentDescription heißt
+  `zurueck_navigation_beschreibung`.
+
+Sonst kollidieren zwei Bedeutungen auf einem Key und in Tests wie Screenshots ist nicht mehr
+unterscheidbar, welches Element gemeint war.
+
+Obsolete Keys sterben in der Änderung, die ihren letzten Consumer löscht. Neue Keys entstehen dort,
+wo sie gerendert werden. Ein Sammel-Issue zum Strings-Aufräumen gibt es bewusst nicht.
+
 ## Dependency Injection: Koin
 
 ```kotlin
@@ -197,34 +213,44 @@ sind im Projekt nicht eingerichtet und deshalb kein Pflichtschritt — siehe
 
 ### Test-Struktur
 
+Ist-Stand, nicht Zielbild:
+
 ```
 app/src/
-├── test/java/com/boltmind/app/           # Unit Tests
+├── test/java/com/boltmind/app/               # JVM, JUnit 5
 │   ├── feature/
-│   │   ├── uebersicht/
-│   │   │   └── UebersichtViewModelTest.kt
-│   │   ├── neuervorgang/
-│   │   │   └── NeuerVorgangViewModelTest.kt
-│   │   ├── demontage/
-│   │   │   └── DemontageViewModelTest.kt
-│   │   └── montage/
-│   │       └── MontageViewModelTest.kt
-│   ├── ui/schrittbrowser/                # F-006 (reine Unit-Tests, kein ViewModel)
-│   │   └── KategorieVonTest.kt           # Kategorie-Ableitung + Index-Grenzfaelle
-│   └── data/repository/
-│       └── ReparaturRepositoryTest.kt
-├── androidTest/java/com/boltmind/app/    # Integration Tests (Zielstruktur, noch nicht angelegt)
-│   └── data/local/
-│       ├── ReparaturvorgangDaoTest.kt
-│       ├── SchrittDaoTest.kt
-│       ├── SchrittFotoDaoTest.kt
-│       └── MigrationTest.kt              # Room-Migrationen (MigrationTestHelper)
+│   │   ├── FormatierungTest.kt               # Datums- und Zeitformate
+│   │   ├── abschluss/AbschlussViewModelTest.kt
+│   │   └── browser/BrowserViewModelTest.kt   # F-003, F-004 und F-001-Archiv
+│   ├── data/
+│   │   ├── foto/FotoManagerTest.kt
+│   │   └── repository/ReparaturRepositoryTest.kt
+│   ├── service/zeiterfassung/ZeiterfassungServiceTest.kt
+│   └── ui/components/DebounceClickTest.kt
+└── androidTest/java/com/boltmind/app/        # Geraet/Emulator, JUnit 4
+    └── data/local/MigrationTest.kt           # Room-Migrationen
 ```
 
-Verbindlich ist derzeit nur der Zweig unter `app/src/test/`. `app/src/androidTest/` existiert im Repo
-noch nicht — `./gradlew connectedAndroidTest` läuft damit ins Leere und darf nicht als bestandener
-Check gemeldet werden (siehe [Werkzeug-Lücken](#werkzeug-lücken-stand-2026-07-26)). Wer den ersten
-Integration Test schreibt, legt das Verzeichnis nach obiger Struktur an.
+Ein einziger `BrowserViewModelTest` deckt Demontage, Montage und Archiv ab, weil ein einziges
+ViewModel alle drei Betriebsarten bedient. Getrennte `DemontageViewModelTest`/`MontageViewModelTest`
+gibt es nicht mehr.
+
+**Beide Zweige sind verbindlich.** `./gradlew test` und `./gradlew connectedDebugAndroidTest` laufen
+und sind zu benutzen — Letzteres braucht ein Gerät oder den Emulator (siehe `CLAUDE.md`).
+
+#### Konvention für `androidTest`
+
+Instrumentierte Tests laufen über `AndroidJUnitRunner` und damit unter **JUnit 4**, nicht JUnit 5.
+`@Nested inner class` gibt es dort nicht. Äquivalent:
+
+| JVM (JUnit 5) | Instrumentiert (JUnit 4) |
+|---|---|
+| `@Nested inner class \`US-XXX_Y ...\`` | eine **Testklasse** je User Story, benannt `UsXxxYBeschreibung` |
+| `@Test fun \`Verhalten aus dem Then\`()` | `@Test fun verhaltenAusDemThen()` — Backticks sind auf dem Gerät zulässig, aber `@DisplayName` fehlt, also trägt der Methodenname die Aussage |
+| `@BeforeEach` / `@AfterEach` | `@Before` / `@After` |
+
+Instrumentierte Tests werden **lokal vor dem PR** ausgeführt. Es gibt keine Build-Pipeline, die das
+übernimmt — wer sie nicht ausgeführt hat, schreibt das in den PR, statt sie als grün zu melden.
 
 ### User-Story-Traceability in Tests
 
@@ -236,6 +262,30 @@ Jede User Story aus der Spec (`US-XXX.Y`) wird als `@Nested inner class` im zuge
 2. **1 Akzeptanzkriterium = 1 `@Test`** — Testname beschreibt das erwartete Verhalten
 3. **Given/When/Then** aus der Spec als Kommentare im Test-Body (Arrange/Act/Assert)
 4. **Spec ist Source of Truth** — Tests leiten sich aus den Akzeptanzkriterien ab, nicht umgekehrt
+
+### Der `aktualisiertAm`-Guard
+
+`governance.md` verlangt, dass **jede** datenverändernde Repository-Operation in derselben Operation
+`Reparaturvorgang.aktualisiertAm` nachzieht. Verstöße sind im Betrieb unsichtbar — die Übersicht
+sortiert dann faktisch nach Erstellungsdatum statt nach letzter Bearbeitung, und das Abschlussdatum
+im Archiv stimmt nicht.
+
+Deshalb wird die Invariante nicht nur aufgeschrieben, sondern **erzwungen**. `ReparaturRepositoryTest`
+führt vier Listen, in die jede öffentliche Methode des Repositories einsortiert sein muss:
+
+| Liste | Bedeutung |
+|---|---|
+| `UEBER_DEN_TRICHTER` | schreibt Daten und stempelt über den Transaktions-Helper — ein `@TestFactory` prüft jede einzeln |
+| `EIGENER_ZEITSTEMPEL` | setzt `aktualisiertAm` selbst (Anlegen, Archivieren) — braucht einen eigenen Test |
+| `OHNE_ZEITSTEMPEL` | schreibt bewusst ohne zu stempeln |
+| `NUR_LESEND` | liest nur |
+
+Ein zweiter Test liest die tatsächliche Methodenliste per Reflection und vergleicht sie mit der
+Summe der vier Listen — in **beide** Richtungen. Eine neue Methode ohne Einsortierung lässt ihn
+fehlschlagen, ein Eintrag ohne Methode ebenso.
+
+**Regel: Wer eine öffentliche Repository-Methode anlegt, umbenennt oder löscht, pflegt diese Listen
+mit.** Das Fehlschlagen ist Absicht und keine Testschwäche.
 
 ### Test-Naming
 
@@ -448,19 +498,20 @@ vorgeschrieben werden:
 | Task | Zweck |
 |------|-------|
 | `./gradlew test` | Unit Tests (JVM, JUnit 5) — der verbindliche Check jedes TDD-Schritts |
+| `./gradlew connectedDebugAndroidTest` | Instrumentierte Tests (Room-Migrationen). Braucht Gerät oder Emulator |
 | `./gradlew lint` | Android Lint |
 | `./gradlew assembleDebug` | Debug-Build |
 
-### Werkzeug-Lücken (Stand 2026-07-26)
+### Werkzeug-Lücken (Stand 2026-07-27)
 
-Formatierung, statische Analyse und Instrumented Tests sind **gewollt, aber nicht eingerichtet**.
+Formatierung, statische Analyse und Compose-UI-Tests sind **gewollt, aber nicht eingerichtet**.
 Die folgende Tabelle beschreibt ein Soll, keinen Ist-Zustand:
 
 | Werkzeug | Soll | Ist |
 |----------|------|-----|
 | ktlint | Automatische Formatierung nach Kotlin Coding Conventions, `./gradlew ktlintCheck` / `ktlintFormat` | **Nicht eingerichtet.** Kein ktlint-Plugin in `build.gradle.kts` oder `gradle/libs.versions.toml`; die Tasks existieren nicht. |
 | detekt | Statische Code-Analyse (Complexity, Code Smells, Style), `./gradlew detekt`, Konfiguration in `config/detekt/detekt.yml` | **Nicht eingerichtet.** Kein detekt-Plugin, kein `config/`-Verzeichnis; die Task existiert nicht. |
-| Instrumented Tests | Room-/DAO-Integrationstests unter `app/src/androidTest/`, `./gradlew connectedAndroidTest` | **Leer.** `app/src/androidTest/` existiert nicht; die Task läuft ins Leere. |
+| Compose-UI-Tests | UI-Tests je Modus und für Mindesthöhen, `createAndroidComposeRule` | **Nicht geschrieben.** Die Abhängigkeiten (`ui-test-junit4`, `ui-test-manifest`) sind eingerichtet, aber es existiert kein einziger UI-Test. |
 
 Bis zur Einrichtung ist **keiner dieser Punkte eine Anforderung**: Er darf in keinem TDD-Zyklus als
 Pflichtschritt stehen, kein PR darf an ihm scheitern, und keine Zusammenfassung darf behaupten, der

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -252,6 +252,23 @@ Instrumentierte Tests laufen über `AndroidJUnitRunner` und damit unter **JUnit 
 Instrumentierte Tests werden **lokal vor dem PR** ausgeführt. Es gibt keine Build-Pipeline, die das
 übernimmt — wer sie nicht ausgeführt hat, schreibt das in den PR, statt sie als grün zu melden.
 
+#### Falle: Endlos-Animationen hängen Compose-Tests auf
+
+Compose synchronisiert Tests gegen die Animationsuhr und wartet auf Ruhe. Zwei Stellen im Projekt
+erreichen sie nie:
+
+| Stelle | Animation |
+|---|---|
+| `ui/schrittbrowser/ThumbnailLeiste.kt` | Atem-Puls des aktiven Thumbnails |
+| `ui/schrittbrowser/FotoKarussell.kt` | pulsierender Wischhinweis |
+
+Ein Test, der den Schritt-Browser betritt, läuft mit Auto-Synchronisierung bis zum Timeout. Er muss
+`composeTestRule.mainClock.autoAdvance = false` setzen und die Uhr mit `advanceTimeBy(...)` von Hand
+stellen.
+
+Splash und Übersicht haben nur endliche Animationen — dort genügt die Voreinstellung. `StartSmokeTest`
+zeigt das Muster inklusive `waitUntil` statt blindem Warten.
+
 ### User-Story-Traceability in Tests
 
 Jede User Story aus der Spec (`US-XXX.Y`) wird als `@Nested inner class` im zugehörigen Test abgebildet. So lässt sich jeder Test direkt auf eine User Story und deren Akzeptanzkriterien zurückverfolgen.
@@ -511,7 +528,7 @@ Die folgende Tabelle beschreibt ein Soll, keinen Ist-Zustand:
 |----------|------|-----|
 | ktlint | Automatische Formatierung nach Kotlin Coding Conventions, `./gradlew ktlintCheck` / `ktlintFormat` | **Nicht eingerichtet.** Kein ktlint-Plugin in `build.gradle.kts` oder `gradle/libs.versions.toml`; die Tasks existieren nicht. |
 | detekt | Statische Code-Analyse (Complexity, Code Smells, Style), `./gradlew detekt`, Konfiguration in `config/detekt/detekt.yml` | **Nicht eingerichtet.** Kein detekt-Plugin, kein `config/`-Verzeichnis; die Task existiert nicht. |
-| Compose-UI-Tests | UI-Tests je Modus und für Mindesthöhen, `createAndroidComposeRule` | **Nicht geschrieben.** Die Abhängigkeiten (`ui-test-junit4`, `ui-test-manifest`) sind eingerichtet, aber es existiert kein einziger UI-Test. |
+Compose-UI-Tests sind **eingerichtet und belegt** (siehe unten) und deshalb keine Lücke mehr.
 
 Bis zur Einrichtung ist **keiner dieser Punkte eine Anforderung**: Er darf in keinem TDD-Zyklus als
 Pflichtschritt stehen, kein PR darf an ihm scheitern, und keine Zusammenfassung darf behaupten, der

--- a/docs/specs/F-001-uebersicht/README.md
+++ b/docs/specs/F-001-uebersicht/README.md
@@ -23,7 +23,7 @@ Mechaniker in der Werkstatt, der morgens die App oeffnet oder zwischen zwei Fahr
 - Neuen Vorgang anlegen (→ F-002)
 - Vorgang loeschen (Swipe + Bestaetigungsdialog, kaskadierend inkl. aller Schritte und Fotos)
 - Archivierte Vorgaenge auflisten (ebenfalls sortiert nach letzter Bearbeitung, mit Abschlussdatum). Ein eigenes Archivierungs-Feld existiert nicht: das Abschlussdatum ist `aktualisiertAm` zum Zeitpunkt des Archivierens und aendert sich danach nicht mehr, weil archivierte Vorgaenge nur lesend geoeffnet werden (governance.md, Invariante `aktualisiertAm`)
-- Gesamtdauer und Dauer je Schritt anzeigen — **setzt F-005 voraus** (Quelle: Tabelle `zeit_messung`). F-005 ist nicht implementiert; bis dahin entfaellt jede Dauer-Anzeige
+- Gesamtdauer und Dauer je Schritt anzeigen — **setzt F-005 voraus** (Quelle: Tabelle `zeit_messung`). Seit 2026-07-27 erfuellt: die Archiv-Liste summiert die abgeschlossenen Messungen beider `referenzTyp`-Werte je Vorgang in derselben Abfrage
 - Archivierten Vorgang im F-006-Modus **nur-lesen** durchsehen: Schritt-Navigation (vor/zurueck und Thumbnail-Sprung) und Foto-Karussell liefert F-006, F-001 implementiert davon nichts selbst. F-001 uebergibt die Schritte **aufsteigend nach `schrittNummer`** (Demontage-Reihenfolge, siehe uebersicht.md US-001.5)
 - Die Archiv-Detailansicht wird ueber die Android-Zurueck-Geste und den Zurueck-Pfeil in der TopBar verlassen — "Zurueck"/"Weiter" als Beschriftung gehoeren allein der F-006-Schritt-Navigation im Inhaltsbereich
 
@@ -35,7 +35,7 @@ Mechaniker in der Werkstatt, der morgens die App oeffnet oder zwischen zwei Fahr
 | → | F-003 | Tap auf Vorgang oeffnet Demontage-Flow |
 | → | F-004 | Tap auf Vorgang oeffnet Montage-Flow |
 | → | F-006 | Archiv-Detailansicht bindet den Schritt-Browser im Modus **nur-lesen** ein: Thumbnail-Leiste, Foto-Karussell, Vollbild und die Vor/Zurueck-Navigation zwischen Schritten kommen vollstaendig aus F-006. F-001 liefert als Eingabe die Schritte **aufsteigend nach `schrittNummer`** |
-| → | F-005 | Liest `zeit_messung`-Daten fuer die Dauer-Anzeige im Archiv. F-005 ist nicht implementiert — ohne F-005 zeigt F-001 keine Dauer |
+| → | F-005 | Liest `zeit_messung`-Daten fuer die Dauer-Anzeige im Archiv. Implementiert |
 
 ## Ordner-Inhalt
 

--- a/docs/specs/F-002-vorgang-anlegen/README.md
+++ b/docs/specs/F-002-vorgang-anlegen/README.md
@@ -24,7 +24,7 @@ Mechaniker, der einen neuen Reparaturauftrag beginnt und das Fahrzeug vor sich s
 - Foto wiederholen vor dem Starten (Aktion am bereits aufgenommenen Foto)
 - Abbruch ueber Back-Button (kein Vorgang wird angelegt)
 
-> **[OFFEN]** Die aktuelle Implementierung weicht davon ab: Sie nutzt CameraX mit app-eigener Kameraansicht und CAMERA-Permission. Die Umstellung auf die System-Kamera steht aus — Details in [anlegen.md](anlegen.md), Abschnitt "Technische Hinweise".
+Die Umstellung auf die System-Kamera ist seit 2026-07-27 umgesetzt: CameraX, die app-eigene Kameraansicht und die `CAMERA`-Permission sind entfernt, das Fahrzeugfoto entsteht über `ActivityResultContracts.TakePicture()` und einen `FileProvider`. Details in [anlegen.md](anlegen.md), Abschnitt "Technische Hinweise".
 
 ## Abhaengigkeiten
 

--- a/docs/specs/F-004-montage/montage.md
+++ b/docs/specs/F-004-montage/montage.md
@@ -303,7 +303,15 @@ Die Kennzahl "GEMESSEN" ist die Summe aller Zeitmessungen des Vorgangs über bei
 
 Ohne diesen Button wäre die Rückkehr vom Abschluss-Screen eine Sackgasse: Es gibt dann keinen offenen Schritt mehr, dessen Abhaken den Abschluss-Screen erneut auslösen könnte. Der Button navigiert nur — archiviert wird weiterhin ausschließlich auf dem Abschluss-Screen.
 
-**[OFFEN]** Beschriftung und Platz des Buttons "Zum Abschluss". Der Prototyp kennt den Fall nicht (dort ist der Fertig-Screen eine Sackgasse ohne Rückweg), das Design-System entscheidet ihn nicht, und wörtlich gebaut ist er nicht. Die Regel "Abschluss nur über den Abschluss-Screen" verlangt ihn trotzdem.
+**Beschriftung und Platz** (entschieden am 2026-07-27, vorher `[OFFEN]`): ein mittlerer, orange gefüllter Rundkreis mit der Beschriftung **„ABSCHLUSS"**, rechts neben „ZURÜCK" und links vom großen Kreis. Der Prototyp kennt den Fall nicht — dort ist der Fertig-Screen eine Sackgasse ohne Rückweg.
+
+Drei Festlegungen dazu:
+
+- **Orange, nicht grün.** Orange ist im Entwurf durchgehend die Aktion, die nach vorne führt („NÄCHSTES", „LOS GEHT'S", „AB INS ARCHIV"). Grün gehört dem Einbau-Zustand.
+- **Zusätzlich statt anstelle.** Der große Kreis bleibt „DRIN", denn er trägt das Zurücknehmen des Häkchens. Würde er zum Abschluss-Knopf, wäre die Korrektur genau in dem Zustand unerreichbar, in dem sie am ehesten gebraucht wird.
+- **Nur in der Montage.** Demontage und Archiv kennen den Knopf nicht.
+
+Der Zustand ist aus den Daten abgeleitet (`alleEingebaut`), nicht gespeichert: Sobald eine Markierung zurückgenommen wird, verschwindet der Knopf von selbst.
 
 Der Ausstieg aus dem Flow ohne Archivierung gehört US-004.6.
 
@@ -478,12 +486,13 @@ Angezeigt wird das in der **Timer-Kapsel** oben links: links ein quadratischer S
 
 ## Offene Fragen
 
-Vier Punkte sind mit `[OFFEN]` markiert und vor der Implementierung zu klären:
+Drei Punkte sind mit `[OFFEN]` markiert und zu klären:
 
 - Fließtext der Ausstiegs-Rückfrage (Abschnitt "Wörtliche UI-Texte")
-- Beschriftung und Platz des Buttons "Zum Abschluss" (US-004.5)
 - Wirkung der Android-Zurück-Geste in der Schritt-Ansicht (US-004.6)
 - Verhalten einer laufenden Zeitmessung beim manuellen Schrittwechsel (US-004.7)
+
+**Erledigt:** Beschriftung und Platz des Buttons "Zum Abschluss" (US-004.5) — am 2026-07-27 entschieden, siehe dort.
 
 **Entschieden:** F-004 nutzt F-006 im Modus **"lesend-mit-Aktionen"**. Die Label eines Fotos sind während der Montage sichtbar, aber nicht änderbar; Fotos werden in der Montage weder aufgenommen noch gelöscht. Label werden ausschließlich in der Demontage (F-003) gesetzt. Die datenverändernden Aktionen der Montage sind das Abhaken (`eingebautBeiMontage`), die Zeitmessung (F-005) und die abschließende Archivierung.
 

--- a/docs/specs/F-004-montage/montage.md
+++ b/docs/specs/F-004-montage/montage.md
@@ -33,6 +33,7 @@ Diese Texte sind verbindlich und werden von UI-Tests wörtlich geprüft. Sie lie
 | Rundbutton, Schritt bereits eingebaut | `DRIN` | `montage_drin` |
 | Rundbutton, Ausstieg | `RAUS` | `montage_raus` |
 | Rundbutton, Schritt-Navigation | `ZURÜCK` (mit Glyphe `↑`) | `browser_zurueck` |
+| Rundbutton, Weg zum Abschluss (nur wenn alles drin ist) | `ABSCHLUSS` | `montage_zum_abschluss` |
 | Hinweis ohne Ablageort-Foto | `AM FAHRZEUG GEBLIEBEN` | `montage_am_fahrzeug` |
 | Rückfrage Ausstieg, Titel | `FEIERABEND?` | `sheet_feierabend_titel` |
 | Rückfrage Ausstieg, Aktionen | `WEITER ARBEITEN` / `JA, FEIERABEND` | `sheet_weiter_arbeiten`, `sheet_ja_feierabend` |

--- a/docs/specs/F-005-zeiterfassung/README.md
+++ b/docs/specs/F-005-zeiterfassung/README.md
@@ -33,7 +33,7 @@ Die Tabelle ist ein reiner Verweis auf die Consumer-Specs. Wann der Timer laeuft
 
 **Zur Zeile F-004:** Die Montage-Zeitmessung ist bewusst zurueckgestellt. F-004 beschreibt bisher weder Start- noch Stopp-Trigger und erwaehnt F-005 in montage.md nicht. Solange das so ist, gibt es **keine** Montage-Zeitmessung — nicht weil der Service sie nicht koennte, sondern weil der Consumer die Nutzung noch nicht festgelegt hat. F-005 darf diese Luecke nicht selbst schliessen (der Service kennt seine Consumer nicht). Die Zeile bleibt hier stehen, damit die geplante Beziehung sichtbar ist; sie ist erst dann erfuellt, wenn F-004 einen eigenen Abschnitt "Ankerpunkt F-005" bekommt, so wie F-003 ihn hat.
 
-**Hinweis (Ist-Zustand):** F-005 ist nicht implementiert. Solange es kein `zeit_messung` gibt, koennen Consumer keine Dauer anzeigen. Consumer-AKs, die eine Dauer verlangen, sind entsprechend als F-005-abhaengig zu kennzeichnen.
+**Hinweis (Ist-Zustand, 2026-07-27):** F-005 ist implementiert — `ZeitMessung`, `ZeitMessungDao` und `ZeiterfassungService` stehen, die Tabelle `zeit_messung` kam mit `MIGRATION_2_3`. Consumer koennen Dauern anzeigen; F-001 tut es in der Archiv-Liste. Die frueher als `[F-005-abhaengig]` markierten Consumer-AKs sind damit erfuellbar.
 
 ## Ordner-Inhalt
 

--- a/docs/specs/F-006-schritt-browser/README.md
+++ b/docs/specs/F-006-schritt-browser/README.md
@@ -12,16 +12,20 @@ Demontage, Montage und Archiv brauchen dieselbe Faehigkeit: durch die Schritte e
 
 Eine wiederverwendbare, zustandslose Komponente mit klarem Interface:
 
-- Eine **horizontale Thumbnail-Leiste** ueber alle Schritte des Vorgangs. Jedes Thumbnail zeigt das erste Foto des Schritts und die Schrittnummer. Ein Tap springt direkt zu diesem Schritt.
-- **Vor-/Zurueck-Bedienelemente** fuer den schrittweisen Wechsel zum benachbarten Schritt. Am ersten bzw. letzten Schritt der Anzeige-Reihenfolge ist das jeweilige Element deaktiviert.
-- Ein **Bildkarussell** fuer die N Fotos des aktuellen Schritts, horizontal wischbar. Ein Tap auf ein Foto oeffnet es als Vollbild.
-- **Label-Anzeige** am aktuell sichtbaren Foto (Bauteil / Uebersicht / Ablageort) — in allen Modi sichtbar, aenderbar nur im bearbeitbaren Modus.
+- Eine **senkrechte Thumbnail-Leiste** am rechten Rand. Sie zeigt nicht alle Schritte, sondern ein Fenster von hoechstens vier Kacheln, das mit dem aktuellen Schritt wandert. Was darueber und darunter liegt, erscheint als Ueberlaufzaehler an den Enden. Jede Kachel zeigt das erste Foto des Schritts, seine Schrittnummer und einen Farbstreifen fuer die Kategorie. Ein Tap springt direkt zu diesem Schritt.
+- Ein **Bildkarussell** fuer die N Fotos des aktuellen Schritts, waagerecht wischbar, darunter Punkt-Indikatoren und ein Zaehler. Ein Tap auf ein Foto oeffnet es als Vollbild.
+- **Label-Anzeige** am aktuell sichtbaren Foto (Bauteil / Uebersicht / Ablageort) — in allen Betriebsarten sichtbar, aenderbar nur in `BEARBEITBAR`. Hat der Schritt kein Foto, gibt es nichts zu beschriften und die Label-Spalte entfaellt.
+- Vier **Slots**, in die der Consumer seine eigenen Bedienelemente einhaengt: `kopfzeile`, `ueberLabels`, `unterLabels`, `bedienkreise`.
 
-Der Browser ist das einzige Bedienkonzept fuer Schritt-Navigation; frueher diskutierte Alternativen (Kreis-Kette in F-004, Nummernfeld-Dialog in F-003) sind damit hinfaellig.
+**Vor/Zurueck ist ein Slot-Element und gehoert dem Consumer.** Der Browser rendert dafuer kein eigenes Bedienelement; er stellt nur `istErster` und `istLetzter` bereit, damit die Randpruefung nicht dreimal neu entsteht. Der Grund ist der Entwurf: die drei Betriebsarten haben unterschiedliche Button-Saetze an derselben Stelle (Demontage „NOCH'N FOTO" und „NÄCHSTES nn", Montage „RAUS", „ZURÜCK" und „SITZT!", Archiv zwei schlichte Pfeile). Ein einheitliches Vor/Zurueck aus dem Browser haette daneben gestanden statt darin.
 
-**Wischgeste (verbindlich):** Horizontales Wischen im Bildbereich wechselt ausschliesslich das **Foto innerhalb des aktuellen Schritts**. Es wechselt **nie** den Schritt. Der Schritt-Wechsel laeuft ueber die Thumbnail-Leiste und die Vor-/Zurueck-Bedienelemente. Diese Zuordnung ist die Kollisionsaufloesung gegenueber F-004, das dieselbe Geste frueher fuer den Schritt-Wechsel vorgesehen hatte.
+Der Thumbnail-Sprung ist damit das einzige Bedienelement fuer den Schritt-Wechsel, das der Browser selbst rendert. Frueher diskutierte Alternativen (Kreis-Kette in F-004, Nummernfeld-Dialog in F-003) sind hinfaellig; einen Sprung-Dialog mit Nummerneingabe gibt es nicht.
 
-**Architektur-Entscheidung:** F-006 ist **kein Service** im Sinne von F-005. Der Browser besitzt keine eigene Tabelle, kein eigenes ViewModel und greift nicht auf Repository oder DAO zu. Er ist eine stateless Compose-Komponente mit State Hoisting: der Consumer liefert den kompletten Zustand hinein und reagiert auf Callbacks. Grund: Die Komponente hat keine eigenen Daten — sie stellt Daten dar, die dem Consumer gehoeren, und meldet Nutzerabsichten zurueck. Persistenz bleibt dort, wo die fachliche Entscheidung faellt.
+**Wischgeste (verbindlich):** Waagerechtes Wischen im Bildbereich wechselt ausschliesslich das **Foto innerhalb des aktuellen Schritts**. Es wechselt **nie** den Schritt. Der Schritt-Wechsel laeuft ueber die Thumbnail-Leiste und die Vor/Zurueck-Elemente des Consumers. Diese Zuordnung ist die Kollisionsaufloesung gegenueber F-004, das dieselbe Geste frueher fuer den Schritt-Wechsel vorgesehen hatte.
+
+**Architektur-Entscheidung:** F-006 ist **kein Service** im Sinne von F-005. Der Browser besitzt keine eigene Tabelle, kein eigenes ViewModel und greift nicht auf Repository oder DAO zu. Er ist eine zustandslose Compose-Komponente mit State Hoisting: der Consumer liefert den Zustand hinein und reagiert auf Rueckrufe. Grund: Die Komponente hat keine eigenen Daten — sie stellt Daten dar, die dem Consumer gehoeren, und meldet Nutzerabsichten zurueck. Persistenz bleibt dort, wo die fachliche Entscheidung faellt.
+
+Eine Ausnahme von „haelt selbst nichts": der Pager des Karussells fuehrt seine Position als eigenen Compose-Zustand. Er wird von aussen nachgezogen, wenn sich der Index oder die Fotoanzahl aendert, und meldet jedes Wischen zurueck. Anders ist ein Pager nicht zu bauen.
 
 **Gemeinsam mit F-005 gilt:** Der Browser kennt seine Consumer nicht. Die Integration wird in den Consumer-Specs beschrieben, nicht hier.
 
@@ -31,51 +35,79 @@ Mechaniker in der Werkstatt — beim Dokumentieren (Demontage), beim Zusammenbau
 
 ## Kernfaehigkeiten
 
-- Thumbnail-Leiste ueber alle Schritte, horizontal scrollbar, aktueller Schritt hervorgehoben
-- Sprung zu einem beliebigen Schritt per Tap auf sein Thumbnail
-- Schrittweises Vor- und Zurueckblaettern zum benachbarten Schritt, an den Raendern deaktiviert
-- Farbliche Markierung des Thumbnails nach Foto-Kategorie des Schritts (Ablageort > Uebersicht > Bauteil)
-- Bildkarussell ueber die N Fotos des aktuellen Schritts, horizontal wischbar (wechselt nur das Foto, nie den Schritt)
-- Vollbild-Anzeige eines Fotos per Tap
-- Label-Anzeige am sichtbaren Foto in allen Modi; Label-Checkboxen bedienbar nur im bearbeitbaren Modus
-- Optionale Consumer-Aktion am sichtbaren Foto (F-003 haengt dort "Wiederholen" ein)
-- Drei Modi: bearbeitbar, lesend-mit-Aktionen, nur-lesen
-- Platzhalter-Bild bei fehlender Foto-Datei, definierter Leer-Zustand ohne Fotos
+- Senkrechte Thumbnail-Leiste mit wanderndem Fenster von hoechstens vier Kacheln, aktueller Schritt hervorgehoben und mit atmendem Ring
+- Ueberlaufzaehler an beiden Enden, wenn mehr Schritte existieren als das Fenster fasst
+- Sprung zu einem beliebigen sichtbaren Schritt per Tap auf sein Thumbnail
+- Farbstreifen am unteren Rand des Thumbnails nach Foto-Kategorie des Schritts (Ablageort > Uebersicht > Bauteil)
+- Bildkarussell ueber die N Fotos des aktuellen Schritts, waagerecht wischbar (wechselt nur das Foto, nie den Schritt)
+- Punkt-Indikatoren, Foto-Zaehler und ein Wisch-Hinweis, solange noch nie gewischt wurde
+- Vollbild-Anzeige eines Fotos per Tap, Schliessen ueber die Zurueck-Geste
+- Label-Anzeige am sichtbaren Foto in allen Betriebsarten; bedienbar nur in `BEARBEITBAR`
+- Drei Betriebsarten: `BEARBEITBAR`, `LESEND_MIT_AKTIONEN`, `NUR_LESEN`
+- Platzhalter-Bild bei fehlender Foto-Datei, davon unterschiedener Leer-Zustand ohne Fotos
+- Grenzflags `istErster` / `istLetzter` fuer die Vor/Zurueck-Elemente des Consumers
 
-## Modi
+## Betriebsarten
 
-Die drei Modi unterscheiden sich ausschliesslich darin, was der Mechaniker im Browser **veraendern** kann. Navigation und Darstellung sind identisch: Thumbnail-Leiste, Vor/Zurueck, Karussell, Vollbild und die Label des sichtbaren Fotos gibt es in allen drei Modi. Nur die Bedienbarkeit der Label und die Andockstelle fuer eine Aktion am Foto haengen am Modus.
+Die drei Betriebsarten unterscheiden sich im Browser **ausschliesslich** darin, ob die Label des sichtbaren Fotos bedienbar sind (`labelAenderbar`). Alles andere — Thumbnail-Leiste, Karussell, Vollbild, Label-Anzeige — ist in allen dreien gleich.
 
-| Modus | Consumer | Label-Checkboxen | Foto aufnehmen | Schritt-Aktionen |
+Was ein Consumer daraus macht, entscheidet er selbst: „Foto aufnehmen" und die Schritt-Aktionen sind Slot-Elemente und tauchen im Browser gar nicht auf. Die Tabelle beschreibt deshalb das **Gesamtbild je Consumer**, nicht drei Schalter im Browser.
+
+| Betriebsart | Consumer | Label | Foto aufnehmen | Schritt-Aktionen |
 |---|---|---|---|---|
-| bearbeitbar | F-003 Demontage | aktiv | ja | ja |
-| lesend-mit-Aktionen | F-004 Montage | sichtbar, nicht aenderbar | nein | ja ("Eingebaut") |
-| nur-lesen | F-001 Archiv | sichtbar, nicht aenderbar | nein | nein |
+| `BEARBEITBAR` | F-003 Demontage | bedienbar | ja (Consumer-Slot) | ja (Consumer-Slot) |
+| `LESEND_MIT_AKTIONEN` | F-004 Montage | sichtbar, nicht aenderbar | nein | ja, „SITZT!" (Consumer-Slot) |
+| `NUR_LESEN` | F-001 Archiv | sichtbar, nicht aenderbar | nein | nein |
 
-**Label werden ausschliesslich in der Demontage gesetzt.** In den beiden lesenden Modi zeigt der Browser die gespeicherten Label des sichtbaren Fotos an, nimmt aber keine Aenderung entgegen.
+**Label werden ausschliesslich in der Demontage gesetzt.** In den beiden lesenden Betriebsarten zeigt der Browser die gespeicherten Label des sichtbaren Fotos flach an und nimmt keine Aenderung entgegen.
 
-"Foto aufnehmen" und "Schritt-Aktionen" liegen beim Consumer — der Browser rendert diese Buttons nicht. Der Modus steuert nur, ob der Browser die zugehoerigen Andockstellen anbietet (Consumer-Aktion am sichtbaren Foto) bzw. ob seine Label-Checkboxen bedienbar sind. Vor/Zurueck und Thumbnail-Sprung sind in **allen drei** Modi verfuegbar.
+Die Label sind **Chips, keine Checkboxen**: eine Zeile je Label mit einem farbigen Punkt links. In den lesenden Betriebsarten fehlt ihnen der Klick-Handler, und sie tragen ein flacheres Glas-Rezept — gesetzte und nicht gesetzte Label bleiben unterscheidbar, aber nichts sieht antippbar aus.
 
 ## Schnittstelle im Ueberblick
 
-| Richtung | Inhalt |
+Der Browser nimmt **zwei gebuendelte Objekte** und **vier Slots** entgegen, keine lose Parameterliste:
+
+```kotlin
+SchrittBrowser(
+    zustand: SchrittBrowserZustand,
+    aktionen: SchrittBrowserAktionen,
+    modifier: Modifier = Modifier,
+    kopfzeile:    @Composable BoxScope.() -> Unit = {},
+    ueberLabels:  @Composable ColumnScope.() -> Unit = {},
+    unterLabels:  @Composable ColumnScope.() -> Unit = {},
+    bedienkreise: @Composable BoxScope.() -> Unit = {}
+)
+```
+
+Das Buendel ist Absicht: der Browser wird von drei Screens komponiert, und es haelt deren Signaturen stabil, wenn eine Aktion dazukommt.
+
+**Rein — `SchrittBrowserZustand`:**
+
+| Feld | Inhalt |
 |---|---|
-| Rein | Liste der Schritte in **Anzeige-Reihenfolge** (der Consumer bestimmt vorwaerts oder rueckwaerts) |
-| Rein | Fotos je Schritt: **ID**, Pfad, Reihenfolge, die drei Label-Flags (Bauteil / Uebersicht / Ablageort). Die ID ist Pflicht, weil der Browser sie in den Callbacks zurueckmeldet |
-| Rein | Modus: bearbeitbar, lesend-mit-Aktionen oder nur-lesen |
-| Rein | Index des aktuell angezeigten Schritts (`-1`, wenn der Vorgang keine Schritte hat) |
-| Rein | Index des aktuell sichtbaren Fotos innerhalb des Schritts (`-1`, wenn der Schritt keine Fotos hat) |
-| Rein | Optionale **Consumer-Aktion am sichtbaren Foto** (Bezeichnung + Callback), nur im bearbeitbaren Modus dargestellt |
-| Raus | **Schritt gewaehlt** — der Nutzer hat ein Thumbnail angetippt |
-| Raus | **Vorheriger Schritt** — der Nutzer hat "Zurueck" angetippt |
-| Raus | **Naechster Schritt** — der Nutzer hat "Weiter" angetippt |
-| Raus | **Foto gewaehlt** — das im Karussell sichtbare Foto hat gewechselt: durch Wischen (US-006.4) **oder** weil der Browser beim Schrittwechsel auf das erste Foto des neuen Schritts zurueckgesetzt hat (US-006.2, US-006.10) |
-| Raus | **Label geaendert** — eine Checkbox am sichtbaren Foto wurde gesetzt oder entfernt (nur bearbeitbarer Modus) |
-| Raus | **Foto-Aktion ausgeloest** — die Consumer-Aktion am sichtbaren Foto wurde angetippt |
+| `schritte` | `List<SchrittMitFotos>` in **Anzeige-Reihenfolge**. Ein Schritt bringt seine Fotos mit; es gibt keine zweite Liste. Der Consumer bestimmt vorwaerts oder rueckwaerts, der Browser sortiert nicht um |
+| `aktiverIndex` | Index des angezeigten Schritts. Voreinstellung `0` |
+| `aktivesFoto` | Index des sichtbaren Fotos im Schritt. Voreinstellung `0` |
+| `betriebsart` | `BEARBEITBAR`, `LESEND_MIT_AKTIONEN` oder `NUR_LESEN` |
+| `vollbild` | ob die Vollbild-Anzeige offen ist |
+| `zeigeWischHinweis` | blendet den Hinweis ein, bis einmal gewischt wurde |
+| `zeigeErledigt` | markiert eingebaute Schritte in der Leiste. Nur in der Montage sinnvoll |
 
-Was der Consumer mit den Callbacks macht (Index fortschreiben, Label persistieren, Kamera starten, Timer stoppen), entscheidet der Consumer. Der Browser schreibt den Index nicht selbst fort — auch nicht bei Vor/Zurueck.
+**Es gibt kein `-1`-Protokoll.** Beide Indizes sind mit `0` vorbelegt und werden fuer die Darstellung auf den gueltigen Bereich geklemmt. Eine leere Schrittliste fuehrt dazu, dass `aktiverSchritt` schlicht `null` ist — der Consumer muss keinen Sonderwert liefern und der Browser keinen erkennen.
 
-**Reset des sichtbaren Fotos beim Schrittwechsel:** Wechselt der angezeigte Schritt (Thumbnail-Sprung oder Vor/Zurueck), setzt der Browser das Karussell auf das **erste** Foto des neuen Schritts und meldet das ueber "Foto gewaehlt". Der Consumer **haelt** den Wert weiterhin — er braucht ihn fuer die Label-Anzeige und die Foto-Aktion —, **setzt ihn aber nicht selbst zurueck**. Er uebernimmt schlicht, was gemeldet wird.
+**Raus — `SchrittBrowserAktionen`:**
+
+| Rueckruf | Ausgeloest durch |
+|---|---|
+| `onSchrittGewaehlt(index)` | Tap auf ein Thumbnail |
+| `onFotoGewaehlt(index)` | das Karussell ist auf einem anderen Foto zur Ruhe gekommen |
+| `onVollbildOeffnen()` | Tap auf das Foto |
+| `onVollbildSchliessen()` | Schliesser oder Zurueck-Geste im Vollbild |
+| `onLabelUmgeschaltet(foto, art)` | ein Label-Chip wurde angetippt (nur `BEARBEITBAR`). Uebergeben wird das ganze `SchrittFoto` und die `LabelArt` |
+
+Was der Consumer damit macht (Index fortschreiben, Label persistieren, Kamera starten, Timer stoppen), entscheidet der Consumer. **Der Browser schreibt keinen Index selbst fort.**
+
+**Reset des sichtbaren Fotos beim Schrittwechsel gehoert dem Consumer.** Er setzt `aktivesFoto` beim Wechsel auf `0` zurueck; der Browser zieht den Pager daraufhin nach. Frueher war es umgekehrt beschrieben — das haette zwei Schreiber auf denselben Wert gesetzt und eine Rueckkopplung erzeugt, die sich als sprunghaftes Karussell zeigt.
 
 Details siehe [browser.md](browser.md).
 
@@ -83,20 +115,21 @@ Details siehe [browser.md](browser.md).
 
 | Verantwortung | Gehoert zu F-006 | Gehoert NICHT zu F-006 |
 |---|---|---|
-| Thumbnail-Leiste rendern und scrollen | Ja | -- |
-| **Schritt-Navigation vollstaendig**: Thumbnail-Sprung sowie Vor/Zurueck inkl. Deaktivierung an den Raendern | Ja | -- |
+| Thumbnail-Leiste rendern, Fenster berechnen, Ueberlauf anzeigen | Ja | -- |
+| Sprung zu einem Schritt per Thumbnail melden | Ja | -- |
+| Grenzflags `istErster` / `istLetzter` bereitstellen | Ja | -- |
 | Foto-Karussell und Vollbild-Anzeige | Ja | -- |
-| Label des sichtbaren Fotos anzeigen (alle Modi) und Aenderung melden (nur bearbeitbar) | Ja | -- |
-| Kategorie eines Schritts fuer die Einfaerbung ableiten | Ja | -- |
+| Label des sichtbaren Fotos anzeigen (alle Betriebsarten) und Aenderung melden (nur `BEARBEITBAR`) | Ja | -- |
+| Kategorie eines Schritts fuer den Farbstreifen ableiten | Ja | -- |
 | Leer-Zustand des Karussells bei einem Schritt **ohne Fotos** | Ja | -- |
 | Platzhalter-Bild bei **fehlender Foto-Datei** | Ja | -- |
-| **Reset des sichtbaren Fotos beim Schrittwechsel**: Karussell auf das erste Foto des neuen Schritts setzen und ueber "Foto gewaehlt" melden | Ja | -- |
+| **Vor/Zurueck rendern** | -- | Consumer (Slot `bedienkreise`), unter Nutzung der Grenzflags |
 | Label-Aenderung **persistieren** | -- | Consumer (Repository, Sofort-Save) |
-| Index nach Vor/Zurueck oder Sprung fortschreiben | -- | Consumer (haelt `aktuellerIndex`) |
-| Wert des sichtbaren Fotos halten (`sichtbaresFotoIndex`) | -- | Consumer — er haelt ihn (fuer Label-Anzeige und Foto-Aktion) und uebernimmt den gemeldeten Wert, **setzt ihn beim Schrittwechsel aber nicht selbst zurueck** |
+| Index nach Vor/Zurueck oder Sprung fortschreiben | -- | Consumer |
+| Sichtbares Foto beim Schrittwechsel zuruecksetzen | -- | Consumer |
 | Schritte abhaken (`eingebautBeiMontage`) | -- | Consumer F-004 |
 | Kamera starten, Foto aufnehmen und anhaengen | -- | Consumer F-003 |
-| Ausfuehren der Aktion am sichtbaren Foto (z.B. "Wiederholen") | -- | Consumer F-003 (F-006 rendert nur die Andockstelle und meldet den Tap) |
+| Aktion am sichtbaren Foto (z.B. „Wiederholen") | -- | Consumer F-003, vollstaendig — Bedienelement **und** Ausfuehrung |
 | Schritt anlegen, abschliessen, Flow beenden | -- | Consumer F-003 / F-004 |
 | Abschluss-Screen und Archivieren | -- | Consumer F-004 |
 | Anzeige-Reihenfolge der Schritte (vorwaerts / rueckwaerts) | -- | Consumer (liefert die sortierte Liste) |
@@ -106,19 +139,19 @@ Details siehe [browser.md](browser.md).
 
 ## Consumer
 
-| Feature | Nutzung | Modus | Beschrieben in |
+| Feature | Nutzung | Betriebsart | Beschrieben in |
 |---|---|---|---|
-| F-003 Demontage | Schritt-Ansicht: Karussell des aktuellen Schritts, Label-Checkboxen, Aktion "Wiederholen" am sichtbaren Foto, Leiste aller bisherigen Schritte | bearbeitbar | F-003 workflow.md / views |
-| F-004 Montage | Navigation durch die Schritte in Montage-Reihenfolge; Label werden nur gelesen, die Schritt-Aktion "Eingebaut" gehoert F-004 | lesend-mit-Aktionen | F-004 montage.md |
-| F-001 Archiv-Detailansicht | Durchblaettern der Dokumentation eines archivierten Vorgangs | nur-lesen | F-001 uebersicht.md |
+| F-003 Demontage | Karussell des aktuellen Schritts, bedienbare Label, eigene Aktionskreise inkl. „Wiederholen" und Vor/Zurueck | `BEARBEITBAR` | F-003 workflow.md / views |
+| F-004 Montage | Schritte in Montage-Reihenfolge; Label werden nur gelesen, Aktionskreise „RAUS" / „ZURÜCK" / „SITZT!" gehoeren F-004 | `LESEND_MIT_AKTIONEN` | F-004 montage.md |
+| F-001 Archiv-Detailansicht | Durchblaettern der Dokumentation eines archivierten Vorgangs, zwei schlichte Pfeile als Vor/Zurueck | `NUR_LESEN` | F-001 uebersicht.md |
 
-F-001 und F-004 bringen **keine eigene Schritt-Navigation** mit. Vor/Zurueck und Thumbnail-Sprung kommen aus F-006; die Consumer reagieren nur auf die Callbacks und schreiben ihren `aktuellerIndex` fort.
+Alle drei Consumer bringen ihre **Vor/Zurueck-Elemente selbst** mit und haengen sie in den Slot `bedienkreise`. Sie nutzen dafuer `istErster` und `istLetzter` aus dem Zustand, statt die Randpruefung je Screen neu zu bauen. Der Thumbnail-Sprung dagegen kommt aus F-006.
 
 ## Abhaengigkeiten
 
 - **Keine Feature-Abhaengigkeiten.** Die Komponente ist autark und kennt keinen ihrer Consumer. Abhaengigkeitsrichtung: Consumer → F-006.
-- **Datenmodell:** Die Entities `Schritt` und `SchrittFoto` gehoeren zum Demontage-Datenmodell (F-003). F-006 nimmt sie nur als Eingabe-Datenstruktur entgegen und greift nicht selbst auf die DB zu.
-- **Governance:** Sofort-Save, 300ms Debounce, Platzhalter-Bild bei fehlender Datei, Foto-Label und Prioritaetsregel (Ablageort > Uebersicht > Bauteil) sowie die verbindlichen **Touch-Target-Mindestmasse** — alles in [../governance.md](../governance.md). F-006 nennt dafuer keine eigenen Zahlen.
+- **Datenmodell:** Die Entities `Schritt` und `SchrittFoto` gehoeren zum Demontage-Datenmodell (F-003). F-006 nimmt sie als `SchrittMitFotos` entgegen und greift nicht selbst auf die DB zu.
+- **Governance:** Sofort-Save, 300ms Debounce, Platzhalter-Bild bei fehlender Datei, Foto-Label und Prioritaetsregel (Ablageort > Uebersicht > Bauteil) sowie die verbindlichen **Touch-Target-Mindestmasse** — alles in [../governance.md](../governance.md). F-006 nennt dafuer keine eigenen Zahlen. Zur Ausnahme fuer Thumbnails siehe [../design-system.md](../design-system.md), K-01.
 
 ## Ordner-Inhalt
 
@@ -128,15 +161,22 @@ F-001 und F-004 bringen **keine eigene Schritt-Navigation** mit. Vor/Zurueck und
 
 ## Entschieden
 
-- [x] **ENTSCHIEDEN:** Der Browser kennt **drei** Modi (bearbeitbar / lesend-mit-Aktionen / nur-lesen). Label werden ausschliesslich in der Demontage gesetzt. Siehe Abschnitt "Modi".
-- [x] **ENTSCHIEDEN:** Die gesetzten Label des sichtbaren Fotos sind **in allen Modi** sichtbar — in den lesenden Modi als nicht bedienbare Anzeige. F-004 braucht das fuer die Ablageort-Kennzeichnung am Foto (US-004.1). Die frueher offene Frage "Labels im nur-lesen-Modus sichtbar?" ist damit mit **Ja** beantwortet.
-- [x] **ENTSCHIEDEN:** Die Schritt-Navigation gehoert vollstaendig F-006 — Thumbnail-Sprung **und** Vor/Zurueck (US-006.10). F-001 und F-004 spezifizieren dafuer keine eigenen Bedienelemente mehr.
-- [x] **ENTSCHIEDEN:** Horizontales Wischen im Bildbereich wechselt das Foto, nie den Schritt (US-006.4).
+- [x] **ENTSCHIEDEN:** Der Browser kennt **drei** Betriebsarten (`BEARBEITBAR` / `LESEND_MIT_AKTIONEN` / `NUR_LESEN`). Label werden ausschliesslich in der Demontage gesetzt. Siehe Abschnitt „Betriebsarten".
+- [x] **ENTSCHIEDEN:** Die gesetzten Label des sichtbaren Fotos sind **in allen Betriebsarten** sichtbar — in den lesenden als nicht bedienbare Anzeige. F-004 braucht das fuer die Ablageort-Kennzeichnung am Foto (US-004.1). Die frueher offene Frage „Label im nur-lesen-Modus sichtbar?" ist damit mit **Ja** beantwortet.
+- [x] **ENTSCHIEDEN:** Der **Thumbnail-Sprung** gehoert F-006. **Vor/Zurueck** gehoert dem Consumer und wird ueber den Slot `bedienkreise` eingehaengt; F-006 liefert dazu die Grenzflags. Einen Sprung-Dialog mit Nummerneingabe gibt es nicht.
+- [x] **ENTSCHIEDEN:** Waagerechtes Wischen im Bildbereich wechselt das Foto, nie den Schritt (US-006.4).
+- [x] **ENTSCHIEDEN:** Kein `-1`-Protokoll fuer leere Listen. Die Indizes werden geklemmt, `aktiverSchritt` ist bei leerer Liste `null`.
 
 ## Offene Fragen
 
 Fuer alle drei Punkte gilt die MVP-Antwort als **bindend**: Sie ist der Stand, gegen den implementiert und getestet wird. Offen ist jeweils nur die spaetere Erweiterung — bis zu einer Entscheidung darueber ist sie **keine Anforderung** und in keinem Feature zu implementieren.
 
-- [ ] **OFFEN:** Soll die Kategorie eines Thumbnails zusaetzlich zur Farbe durch ein Symbol erkennbar sein (Farbfehlsichtigkeit, Sonnenlicht in der Halle)? **MVP (bindend):** nur die in browser.md US-006.3 festgelegte Markierung (Rahmenfarbe + Rahmenstaerke). Ein Symbol ist bis zu einer Entscheidung keine Anforderung und in keinem Feature zu implementieren.
-- [ ] **OFFEN:** Braucht die Vollbild-Anzeige Pinch-Zoom? **MVP (bindend): Nein**, die formatfuellende Anzeige aus US-006.5 reicht. Pinch-Zoom ist bis zu einer Entscheidung keine Anforderung und in keinem Feature zu implementieren.
-- [ ] **OFFEN:** Braucht die Leiste bei sehr vielen Schritten (>50) eine Filter- oder Sprungfunktion (z.B. "nur Schritte mit Ablageort")? **MVP (bindend): Nein**, reines Scrollen (US-006.1). Filter oder Sprungfunktion sind bis zu einer Entscheidung keine Anforderung und in keinem Feature zu implementieren.
+- [ ] **OFFEN:** Soll die Kategorie eines Thumbnails zusaetzlich zur Farbe durch ein Symbol erkennbar sein (Farbfehlsichtigkeit, Sonnenlicht in der Halle)? **MVP (bindend):** nur die in browser.md US-006.3 festgelegte Markierung — ein Farbstreifen am unteren Rand der Kachel. Ein Symbol ist bis zu einer Entscheidung keine Anforderung und in keinem Feature zu implementieren.
+- [ ] **OFFEN:** Braucht die Vollbild-Anzeige Pinch-Zoom? **MVP (bindend): Nein**, die Anzeige aus US-006.5 reicht. Pinch-Zoom ist bis zu einer Entscheidung keine Anforderung und in keinem Feature zu implementieren.
+- [ ] **OFFEN:** Braucht die Leiste bei sehr vielen Schritten (>50) eine Filter- oder Sprungfunktion (z.B. „nur Schritte mit Ablageort")? **MVP (bindend): Nein**, das wandernde Fenster mit Ueberlaufzaehlern aus US-006.1 reicht. Filter oder Sprungfunktion sind bis zu einer Entscheidung keine Anforderung und in keinem Feature zu implementieren.
+
+## Aenderungshistorie
+
+| Datum | Aenderung |
+|---|---|
+| 2026-07-27 | Gegen den gebauten Stand nachgezogen (#109). Korrigiert: Leiste ist senkrecht mit wanderndem Fenster statt waagerecht ueber alle Schritte; Vor/Zurueck gehoert dem Consumer, nicht F-006; kein `FotoAktion`-Parameter; kein `-1`-Protokoll; Betriebsart statt Modus; Label sind Chips, keine Checkboxen; Farbstreifen statt Rahmenfarbe; der Foto-Reset gehoert dem Consumer. Die drei MVP-bindenden Antworten bleiben unveraendert — nur zwei ihrer Begruendungen waren falsch. |

--- a/docs/specs/F-006-schritt-browser/README.md
+++ b/docs/specs/F-006-schritt-browser/README.md
@@ -145,7 +145,9 @@ Details siehe [browser.md](browser.md).
 | F-004 Montage | Schritte in Montage-Reihenfolge; Label werden nur gelesen, Aktionskreise „RAUS" / „ZURÜCK" / „SITZT!" gehoeren F-004 | `LESEND_MIT_AKTIONEN` | F-004 montage.md |
 | F-001 Archiv-Detailansicht | Durchblaettern der Dokumentation eines archivierten Vorgangs, zwei schlichte Pfeile als Vor/Zurueck | `NUR_LESEN` | F-001 uebersicht.md |
 
-Alle drei Consumer bringen ihre **Vor/Zurueck-Elemente selbst** mit und haengen sie in den Slot `bedienkreise`. Sie nutzen dafuer `istErster` und `istLetzter` aus dem Zustand, statt die Randpruefung je Screen neu zu bauen. Der Thumbnail-Sprung dagegen kommt aus F-006.
+Alle drei Consumer bringen ihre **Vor/Zurueck-Elemente selbst** mit und haengen sie in den Slot `bedienkreise`. Der Thumbnail-Sprung dagegen kommt aus F-006.
+
+Fuer die Randpruefung bietet der Browser `istErster` und `istLetzter` an. **Gebaut ist es anders:** der Browser-Screen prueft mit eigenen Feldern (`istErsterSchritt` / `istLetzterSchritt` auf `BrowserUiState`), die Flags des Browsers haben null Aufrufstellen. Die Doppelung ist bekannt und als #127 notiert.
 
 ## Abhaengigkeiten
 

--- a/docs/specs/F-006-schritt-browser/browser.md
+++ b/docs/specs/F-006-schritt-browser/browser.md
@@ -351,7 +351,11 @@ Gilt **ausschliesslich** fuer `BEARBEITBAR` (F-003 Demontage).
   **When** seine Kachel dargestellt wird
   **Then** bleiben Schrittnummer, Farbstreifen und Trefferflaeche unveraendert erhalten
 
-> **[OFFEN]** Womit die fehlende Datei ersetzt wird, ist nicht entschieden. `governance.md`, Abschnitt „Fehlende Dateien", verlangt ein Platzhalter-Bild; der gebaute Stand setzt an `AsyncImage` weder `placeholder` noch `error` und zeigt eine leere Flaeche. Vor der Umsetzung festlegen: App-Icon, Stahltextur oder eigenes Symbol.
+**Die Ersatzdarstellung ist das App-Icon**, gedaempft auf 45 % Deckkraft, im Karussell mit dem Text „Foto fehlt" darunter, in der Thumbnail-Kachel ohne Text (dort waere er unlesbar; die Aussage traegt stattdessen die contentDescription). Festgelegt in [../F-004-montage/montage.md](../F-004-montage/montage.md), Abschnitt „Technische Hinweise"; umgesetzt am 2026-07-27.
+
+> **Nicht zu verwechseln mit US-006.9.** Ein Schritt ohne Fotos ist waehrend der Arbeit normal und zeigt einen gestrichelten Rahmen mit der Schrittnummer. Eine fehlende Datei heisst, dass etwas kaputt ist. Die beiden Faelle haengen auch technisch an verschiedenen Schichten — der Leer-Zustand an einer Zustandsentscheidung im Composable, die fehlende Datei am Ladezustand von Coil. Es gibt keinen Codepfad, auf dem sie sich vermischen koennen; ein Test haelt das fest.
+>
+> Eine **leere** Datei (0 Byte) zaehlt ebenfalls als fehlend. `FotoManager` legt solche Huellen vor dem Kamerastart an; bleibt eine nach einem Abbruch mitsamt Datenbankzeile stehen, ist sie ein kaputtes Foto.
 
 ---
 
@@ -615,8 +619,8 @@ Die Beschriftungen der Slot-Inhalte („ZURÜCK", „‹", „›", „RAUS", �
 
 ## Offene Fragen
 
-- **[OFFEN]** Ersatzdarstellung fuer eine fehlende Foto-Datei — siehe US-006.8.
-- **[OFFEN]** `README.md` dieses Ordners beschreibt Schnittstelle und Schritt-Navigation noch ohne den Entwurf (waagerechte Leiste, `FotoAktion`-Parameter, `-1` als Leer-Index). Bis er nachgezogen ist, gilt diese Datei.
+- Die Ersatzdarstellung fuer eine fehlende Foto-Datei ist **entschieden**: das App-Icon, gedaempft, mit dem Text „Foto fehlt" — festgelegt in [../F-004-montage/montage.md](../F-004-montage/montage.md), Abschnitt „Technische Hinweise", umgesetzt am 2026-07-27. Siehe US-006.8.
+- `README.md` dieses Ordners ist am 2026-07-27 gegen den gebauten Stand nachgezogen. Beide Dateien beschreiben dieselbe Schnittstelle; keine hat mehr Vorrang vor der anderen.
 - Die drei MVP-gebundenen Fragen (Symbol zusaetzlich zur Farbe, Pinch-Zoom im Vollbild, Filter bei sehr vielen Schritten) stehen unveraendert in [README.md](README.md#offene-fragen).
 
 ---

--- a/docs/specs/F-007-splash.md
+++ b/docs/specs/F-007-splash.md
@@ -94,7 +94,7 @@ Verbindlich fuer UI-Tests, alle in `res/values/strings_splash.xml`:
 
 ## Offene Fragen
 
-- **[OFFEN]** Der Entwurf legt hinter Wortmarke und Claim eine **Videoschleife** (`assets/splash-loop.mp4`, formatfuellend, Deckkraft 0,85, stumm, endlos). Die Datei liess sich aus dem Design-Projekt nicht exportieren. Derzeit traegt die Stahltextur den Grund, mit demselben Verlauf darueber. Zu entscheiden: Video nachreichen oder die Textur festschreiben.
+- **[OFFEN]** Der Entwurf legt hinter Wortmarke und Claim eine **Videoschleife** (`assets/splash-loop.mp4`, formatfuellend, Deckkraft 0,85, stumm, endlos). Die Datei liess sich aus dem Design-Projekt nicht exportieren. Der gebaute Stand zeigt stattdessen eine ruhige, einfarbige Flaeche (`BoltRuhigerHintergrund`) — die zwischenzeitlich verwendete Stahltextur ist am 2026-07-27 projektweit entfernt worden. Zu entscheiden: Video nachreichen oder die ruhige Flaeche festschreiben.
 - **[OFFEN]** Erscheint der Splash bei **jedem** Start oder nur beim Kaltstart? Der gebaute Stand macht ihn zur Start-Route des NavHost; er erscheint also immer dann, wenn der Prozess neu aufgebaut wird — auch nach einem Kill im Hintergrund waehrend der Arbeit an einem Vorgang. Ob das gewollt ist oder ein Warmstart direkt in die Uebersicht fuehren soll, ist nicht entschieden.
 
 ---

--- a/docs/specs/design-system.md
+++ b/docs/specs/design-system.md
@@ -171,7 +171,7 @@ der Entwurf, in drei die Regel — jeweils dort, wo Datenintegrität dranhängt.
 
 | # | Punkt | Entscheidung |
 |---|---|---|
-| K-01 | Trefferflächen | **Regel** — Sekundärelemente auf 56dp, Thumbnails mit Ausnahme (oben) |
+| K-01 | Trefferflächen | **Regel** — Sekundärelemente auf 56dp, Thumbnails mit Ausnahme (oben). Seit 2026-07-27 testgesichert: `DimensionenTest` bewacht die Token-Werte, `MindesthoeheTest` belegt, dass ein äußeres `.height(40.dp)` die Aktion nicht unter 56dp drückt |
 | K-02 | „Wiederholen" löscht vor dem Kamerastart | **Regel** — erst nach bestätigter Neuaufnahme löschen. Ein Abbruch darf nie ein Foto vernichten. Das neue Foto übernimmt die `reihenfolge` des alten |
 | K-03 | Timer von Hand start-/stoppbar | **Entwurf** — die F-005-Spec sagt „läuft durch, keine Pause". Der Entwurf hat einen Play/Pause-Schalter, und `ZeitMessung` trägt Pausen ohnehin (jedes Start/Stopp-Paar ist eine Zeile). **F-005 muss nachgezogen werden** |
 | K-04 | Timer auch in der Montage | **Entwurf** — bisher unspezifiziert. `referenzTyp = MONTAGE_SCHRITT` |


### PR DESCRIPTION
## 1. Der Fehler, mit dem alles anfing

Waren in der Montage **alle** Schritte abgehakt, gab es keinen Weg mehr zum Abschluss-Screen — der Vorgang liess sich nie archivieren und blieb dauerhaft in der offenen Liste. Einziger Ausweg: ein Haekchen ueber den Warndialog zuruecknehmen und neu setzen.

`montage.md` verlangt an zwei Stellen das Gegenteil (US-004.5), beides stand als Aufgabe in #83 und #85 — beide Issues waren geschlossen:

| Spec | Gefordert | Vorher |
|---|---|---|
| `montage.md:75` | Wiedereinstieg bei vollstaendig abgehaktem Vorgang → direkt Abschluss-Screen | Index 0, `fertig` bleibt `false` |
| `montage.md:300` | Button „Zum Abschluss", solange kein Schritt offen ist | existierte nicht |

Gefixt ueber `alleEingebaut` (abgeleitet, nicht gespeichert — eine leere Schrittliste zaehlt ausdruecklich nicht dazu), `fertig = true` beim **ersten** Laden, und einen orangen Mittelkreis „ABSCHLUSS" neben „ZURÜCK". Der grosse Kreis bleibt „DRIN", damit das Zuruecknehmen erreichbar bleibt.

## 2. R5 „Absicherung" — sechs Issues

Aufgaben, die in #88, #91, #92 und #79 standen und beim Schliessen jener Issues unerledigt blieben.

| # | Was |
|---|---|
| #104 | Compose-UI-Harness mit `StartSmokeTest` belegt. **Nebenbefund:** der Browser haelt zwei Endlos-Animationen, gegen die Compose bis zum Timeout auf Ruhe wartet — jeder kuenftige UI-Test dort muss `mainClock.autoAdvance` abschalten. Steht jetzt in `CODING_RULES.md` |
| #105 | `GlasAktion` wiederholte den Fehler des geloeschten `BoltMindButton`: Mindesthoehe **hinter** dem Aufrufer-Modifier, am Emulator als 40dp statt 56dp nachgemessen. Das Minimum steht jetzt zweimal — blosses Umsortieren waere eine Regression gewesen, weil ein Aufrufer-Padding sonst die Glasflaeche von 56dp auf 36dp gedrueckt haette |
| #106 | Guard-Tests fuer EXIF-Stripping und die „Wiederholen"-Reihenfolge. Mit zwei Mutationen gegengeprueft — beide fallen |
| #107 | Platzhalter-Bild bei fehlender Foto-Datei. Strukturell getrennt vom Leer-Zustand: der eine haengt an einer Zustandsentscheidung, der andere am Ladezustand von Coil |
| #108 | Diagnose war falsch und wurde korrigiert — siehe unten |
| #109 | F-006-README gegen den Code nachgezogen, 38 Abweichungen |

## 3. Eine falsche Diagnose, empirisch widerlegt

Ich hatte den harten Ring um die Aktionskreise auf `Paint.setShadowLayer` in `zeichneLeuchten` zurueckgefuehrt. **Das war plausibel und falsch.** Am Emulator in drei Schritten eingegrenzt:

1. `zeichneLeuchten` vollstaendig deaktiviert → der gruene Schein um „SITZT!" verschwand, **der Ring blieb**
2. `boltKlick` setzt `indication = null` → eine Ripple ebenfalls ausgeschlossen
3. Echtes Foto gesetzt → die Kugel las sich als saubere Kuppel

Die Ursache ist die **dekorative Kugel** in `SchrittBrowser.kt:151`. Sie trug versehentlich `GlasRezepte.kapsel` — Fuellung `BoltPanel55`, also die Hintergrundfarbe bei 55 %, auf Schwarz unsichtbar; sichtbar blieb nur ihr 15-%-Rand als nackter 296dp-Kreis. Das Indiz lag im Code: `BoltKugelHell` trug den Kommentar „Kugel unten rechts im Browser" und wurde nirgends verwendet.

## 4. Doku auf den gebauten Stand

`CODING_RULES.md` behauptete an drei Stellen, `androidTest/` existiere nicht — dort laufen vier Migrationstests. Dazu drei Regeln nachgetragen, die als Aufgabe in geschlossenen Issues standen: androidTest-Konvention (#88), `browser_`-Praefix (#93), `aktualisiertAm`-Guard (#89).

Vier Spec-Stellen beschrieben den gebauten Stand falsch: F-002 nannte CameraX und `CAMERA`-Permission als Ist-Zustand (beides entfernt), F-001 und F-005 behaupteten dreimal „F-005 ist nicht implementiert", F-007 nannte die entfernte Stahltextur.

## Nachweis

- `./gradlew test` — **188 Tests, 0 Fehler** (vorher 169)
- `./gradlew connectedDebugAndroidTest` — **13 Tests, 0 Fehler** (vorher 4), auf `boltmind36`
- `./gradlew assembleDebug lint` — durch
- Am Emulator mit gesetzter Datenbank durchgespielt, DB-Stand nach jedem Tap gelesen:

```
Start:                4 Schritte, alle eingebautBeiMontage=1, status=OFFEN
Montage starten    -> Abschluss-Screen direkt, "4 TEILE / 6 min 40 s"
Back               -> Schritt-Ansicht, oranger Kreis "ABSCHLUSS" sichtbar
Haekchen weg       -> "3 VON 4 DRIN", Kreis verschwunden, DRIN -> SITZT!
SITZT!             -> Abschluss-Screen
AB INS ARCHIV      -> status=ARCHIVIERT, Haken 1,1,1,1
```

Platzhalter und Kugel zusaetzlich visuell gegengeprueft — mit fehlender Datei, mit echtem Foto und auf schwarzem Grund.

Closes #104, #105, #106, #107, #108, #109

## Dabei entstandene Folge-Issues

#118 (Platzhalter an den drei uebrigen `AsyncImage`-Stellen), #119 (Unit-Tests fuer die zustandslose Browser-Logik, von `browser.md` gefordert und nie geschrieben), #120 (vier Abweichungen in der Umsetzung der Glas-Effekte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Nachtrag 2026-07-31: Review und Nacharbeit

Der CI-Check `claude-review` war gruen, hat aber null Kommentare hinterlassen — es hatte
faktisch kein Review stattgefunden. Nachgeholt ueber sechs unabhaengige Pruefdimensionen mit
adversarischer Gegenpruefung der Befunde.

### Nachgefahrene Belege

| Pruefung | Ergebnis |
|---|---|
| `./gradlew test --rerun-tasks` | 189 Tests, 0 Fehler, 0 skipped (erzwungener Lauf, kein Cache) |
| `./gradlew connectedDebugAndroidTest` | 13 Tests, 0 failures, 0 errors auf `boltmind36` |
| `./gradlew assembleDebug lint` | gruen, 0 Lint-Errors |

Die Zahlen des urspruenglichen PR-Bodys stimmten. 188 → 189 durch den unten ergaenzten Test.

### Was der Review gefunden und dieser Branch behoben hat

**1. Testluecke am eigenen Kernfix** (`2e23e64`)

Die Bedingung `ersteLadung &&` ist das, was den Abschluss-Screen davon abhaelt, eine Falle zu
werden: Back verlaesst ihn, die naechste Datenmeldung wuerfe den Mechaniker sonst sofort
zurueck. Kein Test deckte sie ab — ihr Streichen ueberlebte die gesamte Suite. Der neue Test
faellt bei genau dieser Mutation.

Nebenbefund fuer kuenftige Tests: eine zweite Emission muss sich vom Vorzustand unterscheiden,
`MutableStateFlow` konflatiert gleiche Werte. Der erste Anlauf des Tests war deshalb wirkungslos.

**2. Drei Widersprueche, die dieser Branch selbst erzeugt hatte** (`c602d42`)

- `CODING_RULES.md` nannte Compose-UI-Tests im selben Abschnitt „nicht eingerichtet" (Z. 524)
  und „eingerichtet und belegt" (Z. 531). Der zweite Satz klebte ohne Leerzeile an der Tabelle
  und fiel damit unter „Bis zur Einrichtung ist keiner dieser Punkte eine Anforderung".
- Der als „Ist-Stand" deklarierte Testbaum kannte fuenf der dreizehn Testdateien nicht,
  darunter den ganzen androidTest-UI-Zweig.
- `CLAUDE.md` behauptete „175 JVM-Tests" und „Keine Compose-UI-Tests — siehe #104", waehrend
  dieser Branch neun davon anlegt und #104 selbst schliesst.

**3. Eine gekippte Produktentscheidung, die niemand entschieden hatte** (`3d066c7`)

Der Branch schrieb die F-006-README von „Die Schritt-Navigation gehoert vollstaendig F-006"
auf „Vor/Zurueck gehoert dem Consumer" um. `CLAUDE.md` fuehrte weiter die alte Fassung — im
Abschnitt „Produktentscheidungen, die aelteren Staenden vorgehen", der sich selbst fuer
vorrangig erklaert. Beide sind Pflichtlektuere.

Entschieden zugunsten des gebauten Stands: die drei Betriebsarten haben an derselben Stelle
unterschiedliche Bedienelemente. Die Begruendung der README stimmte dabei nicht — die
angeblich genutzten Grenzflags `istErster`/`istLetzter` haben null Aufrufstellen (jetzt #127).

### Bewusst nicht in diesem PR

| # | Warum |
|---|---|
| #124 | Die Montage-Bedienzeile braucht mit dem vierten Kreis 402 dp und staucht den Hauptknopf auf 360-dp-Geraeten. Statisch hergeleitet, am 411-dp-Emulator unsichtbar. Die Loesung ruettelt an der gerade festgeschriebenen Spec und gehoert nicht in diesen PR. |
| #125 | Zwei Smoke-Tests belegen weniger, als ihr Name sagt. |
| #126 | `BrowserViewModel` liegt mit 279 Zeilen ueber dem 200-LOC-Limit — schon vor diesem PR (265). |
| #127 | Grenzflags doppelt, F-006-Variante unbenutzt. |

### Restrisiko

Das Projekt hat keine Build-/Test-Pipeline; alle Laeufe oben sind lokal. Die neun Compose-UI-
Tests liefen nur auf `boltmind36` (Android 16, arm64), nicht auf anderen API-Levels. Der
Layout-Befund #124 ist rein statisch hergeleitet und auf keinem schmalen Geraet angesehen.
