### PR TITLE
[F-003] Der Schritt beginnt mit der Kamera, nicht mit einer leeren Maske

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ Gerät ändert sich nur das Ziel — USB-Debugging genügt, Android 12 oder neue
 
 **Offen:** achtzehn Issues, neun je Milestone. **R5** ist Arbeit ohne Entscheidungsbedarf —
 darunter die Glas-Effekt-Abweichungen (#120), die gestauchte Montage-Bedienzeile (#124) und
-die LOC-Grenze des `BrowserViewModel` (#126, inzwischen 340 Zeilen). Die Demontage-Sackgasse
+die LOC-Grenze des `BrowserViewModel` (#126, inzwischen 368 Zeilen). Die Demontage-Sackgasse
 nach Feierabend (#121) ist mit dem Kamera-Umbau vom 2026-08-01 erledigt: der Einstieg ohne
 offenen Schritt legt jetzt einen an — Issue noch zu schließen.
 
@@ -305,7 +305,7 @@ Bei Design-Entscheidungen in dieser Reihenfolge abwägen.
 ## Verbotene Patterns
 
 - Business-Logik in Composables
-- ViewModel > 200 LOC (gemessen: Browser 279, Uebersicht 146, NeuerVorgang 141, Abschluss 69 — `BrowserViewModel` reisst das Limit, weil es alle drei Betriebsarten bedient; offen als #126)
+- ViewModel > 200 LOC (gemessen am 2026-08-01: Browser 368, Uebersicht 146, NeuerVorgang 146, Abschluss 69 — `BrowserViewModel` reisst das Limit, weil es alle drei Betriebsarten bedient; offen als #126). Die Zahlen sind mit `wc -l` zu messen, nicht zu schaetzen
 - Synchrone DB-Calls auf Main-Thread
 - Wildcard-Imports
 - `GlobalScope`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ unterscheidet sich noch.
 |---|---|---|
 | **F-001** Übersicht | ✅ | Tabs, Vorgangsliste mit Dauer im Archiv, Leerzustände, FAB, Auswahl- und Lösch-Sheet. Vier-Stufen-Datumsregel. Archiv-Detailansicht ist der Browser im Modus ARCHIV. |
 | **F-002** Anlage | ✅ | System-Kamera, Pflicht-Auftragsnummer, Beschreibungsfeld, Direktstart in die Demontage. CameraX und `CAMERA`-Permission sind raus. |
-| **F-003** Demontage | ✅ | Browser im Modus DEMONTAGE. Am Emulator durchgeklickt. |
+| **F-003** Demontage | ✅ | Browser im Modus DEMONTAGE. Der Schritt beginnt mit der Kamera, nicht mit einer leeren Maske; ein Abbruch am frisch eröffneten Schritt rollt zurück. Am 2026-08-01 am Emulator gegen die Datenbank verifiziert. |
 | **F-004** Montage | ✅ | Modus MONTAGE plus Abschluss-Screen. Am 2026-07-27 mit gesetzter Datenbank durchgespielt: Wiedereinstieg, Abhaken, Häkchen zurücknehmen, Archivieren. |
 | **F-005** Zeiterfassung | ✅ | `ZeitMessung`, DAO, Service, Timer-Chip. Pausierbar — siehe unten. |
 | **F-006** Schritt-Browser | ✅ | `ui/schrittbrowser/`, zustandslos, drei Betriebsarten. |
@@ -190,7 +190,7 @@ unterscheidet sich noch.
 Der Timer ist von Hand pausierbar, und die Montage misst ebenfalls. Beides kippt eine
 zuvor bindende MVP-Antwort in `F-005/service.md`.
 
-**Tests:** 189 JVM-Tests (`./gradlew test`) plus 13 instrumentierte Tests
+**Tests:** 207 JVM-Tests (`./gradlew test`) plus 13 instrumentierte Tests
 (`./gradlew connectedDebugAndroidTest`) — vier Room-Migrationen und neun Compose-UI-Tests.
 Das UI-Test-Harness steht seit #104; die Konventionen und die Animations-Falle stehen in
 `docs/CODING_RULES.md`.
@@ -200,8 +200,15 @@ Das UI-Test-Harness steht seit #104; die Konventionen und die Animations-Falle s
 Gerät ändert sich nur das Ziel — USB-Debugging genügt, Android 12 oder neuer.
 
 **Offen:** achtzehn Issues, neun je Milestone. **R5** ist Arbeit ohne Entscheidungsbedarf —
-darunter die Demontage-Sackgasse nach Feierabend (#121), die Glas-Effekt-Abweichungen (#120),
-die gestauchte Montage-Bedienzeile (#124) und die LOC-Grenze des `BrowserViewModel` (#126).
+darunter die Glas-Effekt-Abweichungen (#120), die gestauchte Montage-Bedienzeile (#124) und
+die LOC-Grenze des `BrowserViewModel` (#126, inzwischen 340 Zeilen). Die Demontage-Sackgasse
+nach Feierabend (#121) ist mit dem Kamera-Umbau vom 2026-08-01 erledigt: der Einstieg ohne
+offenen Schritt legt jetzt einen an — Issue noch zu schließen.
+
+**Neuer Befund vom 2026-08-01, noch ohne Issue:** die Android-Zurück-Geste verlässt die
+Demontage zur Übersicht, obwohl `workflow.md` US-003.6 „Beenden" als einzigen Ausstieg
+festlegt. Der einzige `BackHandler` sitzt im Vollbild (`SchrittBrowser.kt`), nicht auf
+Ebene der Schritt-Ansicht.
 **R6** sind Produktfragen, die eine Antwort brauchen, bevor Code entsteht — darunter das
 Splash-Video und die zwei Timer-Entscheidungen aus #94.
 
@@ -235,15 +242,9 @@ Arbeit, die in PR #98 ohne Issue entstand.
 - **Cleanup-Regel (governance.md):** beim App-Start werden Dateien in `photos/` gelöscht, auf die keine DB-Zeile verweist — geprüft gegen `SchrittFoto.pfad` **und** `Reparaturvorgang.fahrzeugFotoPfad`.
 - Foto-Qualität ist bei einer fremden Kamera-App **nicht steuerbar**: ca. 2–3 MB sind ein Erwartungswert, keine erzwingbare Vorgabe. Die App übernimmt die gelieferte Datei wie sie ist.
 
-**Ist-Zustand im Code — weicht ab:**
+**Ist-Zustand im Code:** entspricht dem Zielzustand. Beide Features nutzen die System-Kamera über `ActivityResultContracts.TakePicture()` + `FileProvider`; CameraX ist in keiner Gradle-Datei mehr, die `CAMERA`-Permission steht nicht im Manifest (dort nur ein Kommentar, warum sie fehlt). Die früher hier beschriebene Abweichung — CameraX in F-002, app-eigene Foto-Bestätigung in F-003 — ist erledigt (geprüft am 2026-08-01).
 
-| | F-002 Anlage | F-003 Demontage |
-|---|---|---|
-| Implementierung | **CameraX**, app-eigene Kameraansicht (`NeuerVorgangScreen.kt`) | System-Kamera, `ActivityResultContracts.TakePicture()` + `FileProvider` |
-| `CAMERA`-Permission | wird zur Laufzeit abgefragt, steht im Manifest | nicht nötig |
-| Nach dem Auslösen | Foto direkt ins Formular, „Bild wiederholen" | System-Bestätigung, **dann nochmal** App-Bestätigen/Wiederholen |
-
-`architecture.md` und `F-002/anlegen.md` kennzeichnen diese Abweichung inzwischen korrekt als Ist-Zustand. Umzustellen sind: CameraX und `CAMERA`-Permission raus (F-002), app-eigene Foto-Bestätigung raus (F-003).
+**Wer die Kamera startet:** in beiden Features das **ViewModel**, nicht die Route bzw. der Screen. Der Zustand trägt einen `KameraAuftrag`; die Route hängt einen `LaunchedEffect` daran. In F-003 trägt der Auftrag zusätzlich die **Ziel-Schritt-Id**, damit ein Foto nicht am betrachteten Schritt landet — der ist unmittelbar nach „NÄCHSTES TEIL" für einen Moment noch der eben abgeschlossene. Ein Tap darf die Kamera nie direkt starten: sonst läuft sie parallel zur Schritt-Anlage. Details in `docs/specs/F-003-demontage/workflow.md`, Abschnitt „Reihenfolge beim Schritt-Start".
 
 `FotoManager` kapselt das Dateihandling und hängt noch am alten Zyklus:
 - `photos/temp/` = unbestätigte Aufnahmen, wird bei App-Start via `BoltMindApplication.onCreate()` geleert — **entfällt im Zielzustand**

--- a/app/src/androidTest/java/com/boltmind/app/ui/KameraAnbindungTest.kt
+++ b/app/src/androidTest/java/com/boltmind/app/ui/KameraAnbindungTest.kt
@@ -1,0 +1,93 @@
+package com.boltmind.app.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.boltmind.app.ui.components.KameraAnbindung
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Belegt, dass ein Kamera-Auftrag genau einmal startet.
+ *
+ * Der Test existiert, weil das Projekt diesen Fehler schon einmal gebaut hat: als
+ * die Kamera-Hoheit vom Tap in den ViewModel-Zustand wanderte, blieb der Start in
+ * einem `LaunchedEffect` haengen, der an den Auftrag gebunden ist. Der Auftrag
+ * liegt im ViewModel und ueberlebt eine Neuerstellung der Activity -- die
+ * Komposition nicht. Dreht der Mechaniker das Telefon, waehrend er fotografiert,
+ * laeuft der Effekt in der neuen Komposition erneut an und die Kamera oeffnet ein
+ * zweites Mal.
+ *
+ * Durch Ausprobieren ist das kaum zu finden: es braucht einen Konfigurationswechsel
+ * genau waehrend die fremde Kamera-App im Vordergrund steht.
+ *
+ * Ausfuehren: ./gradlew connectedDebugAndroidTest  (Emulator oder Geraet noetig)
+ */
+@RunWith(AndroidJUnit4::class)
+class KameraAnbindungTest {
+
+    @get:Rule
+    val regel = createComposeRule()
+
+    @Test
+    fun startet_denselben_auftrag_nach_wiederherstellung_nicht_erneut() {
+        // Given: ein offener Auftrag, der die Kamera einmal gestartet hat
+        val wiederhersteller = StateRestorationTester(regel)
+        var starts = 0
+        wiederhersteller.setContent {
+            KameraAnbindung(
+                auftragsNummer = 1,
+                zielPfad = PFAD,
+                onKeineKameraApp = {},
+                starte = { starts++ }
+            )
+        }
+        regel.waitForIdle()
+        assertEquals("Der Auftrag muss ueberhaupt erst einmal starten", 1, starts)
+
+        // When: die Activity wird neu erstellt -- der Auftrag im ViewModel bleibt
+        wiederhersteller.emulateSavedInstanceStateRestore()
+        regel.waitForIdle()
+
+        // Then: kein zweiter Start. Sonst stuende die Kamera doppelt auf dem Stapel
+        assertEquals(1, starts)
+    }
+
+    @Test
+    fun startet_einen_neuen_auftrag_nach_der_wiederherstellung_sehr_wohl() {
+        // Given: ein gestarteter Auftrag, danach eine Wiederherstellung
+        val wiederhersteller = StateRestorationTester(regel)
+        var starts = 0
+        var pfad by mutableStateOf(PFAD)
+        wiederhersteller.setContent {
+            KameraAnbindung(
+                auftragsNummer = 1,
+                zielPfad = pfad,
+                onKeineKameraApp = {},
+                starte = { starts++ }
+            )
+        }
+        regel.waitForIdle()
+        wiederhersteller.emulateSavedInstanceStateRestore()
+        regel.waitForIdle()
+
+        // When: der Mechaniker fordert eine weitere Aufnahme an. Nach einem
+        // Prozesstod faengt der Zaehler im ViewModel wieder bei eins an, deshalb
+        // unterscheidet nur der Zielpfad die beiden Auftraege
+        pfad = ZWEITER_PFAD
+        regel.waitForIdle()
+
+        // Then: die Sperre darf die neue Aufnahme nicht verschlucken
+        assertEquals(2, starts)
+    }
+
+    private companion object {
+        const val PFAD = "/photos/schritt_1.jpg"
+        const val ZWEITER_PFAD = "/photos/schritt_2.jpg"
+    }
+}

--- a/app/src/main/java/com/boltmind/app/data/repository/ReparaturRepository.kt
+++ b/app/src/main/java/com/boltmind/app/data/repository/ReparaturRepository.kt
@@ -133,6 +133,20 @@ class ReparaturRepository(
     }
 
     /**
+     * Macht einen Schritt wieder zum offenen Schritt.
+     *
+     * Gegenstueck zu [schrittAbschliessen], gebraucht beim Rollback eines
+     * abgebrochenen Schritt-Starts: der eben angelegte Schritt verschwindet und
+     * sein Vorgaenger muss wieder der offene sein, sonst hat der Vorgang gar
+     * keinen offenen Schritt mehr (F-003 workflow.md, "Rollback beim Abbruch am
+     * frischen Schritt").
+     */
+    suspend fun schrittWiederOeffnen(schrittId: Long) {
+        val vorgangId = schrittDao.findeVorgangId(schrittId)
+        beruehrend(vorgangId) { schrittDao.setzeAbschluss(schrittId, null) }
+    }
+
+    /**
      * Verwirft einen Schritt vollstaendig. Wird beim "Beenden" eines offenen Schritts
      * ohne Fotos benutzt: sonst bliebe ein leeres Thumbnail zurueck und eine
      * Schrittnummer waere verbrannt.

--- a/app/src/main/java/com/boltmind/app/feature/browser/BrowserFotoSteuerung.kt
+++ b/app/src/main/java/com/boltmind/app/feature/browser/BrowserFotoSteuerung.kt
@@ -34,6 +34,36 @@ class BrowserFotoSteuerung(
         return neu
     }
 
+    /**
+     * Nimmt einen Schritt-Start vollstaendig zurueck und meldet, ob es dazu kam.
+     *
+     * Aufgerufen, wenn genau die Kamera abbricht, die den Schritt eroeffnet hat.
+     * Zurueckgerollt wird nur, wenn der Schritt kein einziges Foto hat und es
+     * einen Vorgaenger gibt, der wieder der offene werden kann -- ohne ihn haette
+     * der Vorgang danach keinen offenen Schritt mehr und der Mechaniker saesse
+     * fest (workflow.md, "Rollback beim Abbruch am frischen Schritt").
+     *
+     * Die Wirkung ist die exakte Umkehrung von [naechstesTeil], Zeitmessung
+     * eingeschlossen.
+     */
+    suspend fun schrittStartZuruecknehmen(schrittId: Long): Boolean {
+        val schritt = repository.findSchritt(schrittId) ?: return false
+        if (repository.holeFotos(schrittId).isNotEmpty()) return false
+        val vorgaenger = repository.holeSchritte(schritt.reparaturvorgangId)
+            .filter { it.schrittNummer < schritt.schrittNummer }
+            .maxByOrNull { it.schrittNummer }
+            ?: return false
+
+        zeiterfassung.stoppeFallsLaeuft(schrittId, ReferenzTyp.DEMONTAGE_SCHRITT)
+        repository.schrittVerwerfen(schrittId)
+        repository.schrittWiederOeffnen(vorgaenger.id)
+        zeiterfassung.starten(vorgaenger.id, ReferenzTyp.DEMONTAGE_SCHRITT)
+        return true
+    }
+
+    /** Die Datei, in die die System-Kamera als naechstes schreiben soll. */
+    fun neueZieldatei(): String = fotoManager.erstelleZieldatei("schritt").absolutePath
+
     /** Haengt ein frisch aufgenommenes Foto an den betrachteten Schritt. */
     suspend fun fotoUebernehmen(schrittId: Long, pfad: String) {
         fotoManager.entferneExifMetadaten(pfad)

--- a/app/src/main/java/com/boltmind/app/feature/browser/BrowserUiState.kt
+++ b/app/src/main/java/com/boltmind/app/feature/browser/BrowserUiState.kt
@@ -7,6 +7,33 @@ import com.boltmind.app.ui.navigation.BrowserModus
 import com.boltmind.app.ui.schrittbrowser.BrowserBetriebsart
 import com.boltmind.app.ui.schrittbrowser.SchrittBrowserZustand
 
+/**
+ * Ein offener Kamera-Auftrag.
+ *
+ * Das ViewModel legt die Zieldatei an und reicht sie hier hoch; die Route haengt
+ * ihren Launcher daran. Dass der Auftrag im State steht statt in der Route,
+ * loest ein Reihenfolgeproblem: die Kamera kann erst starten, wenn der Schritt,
+ * fuer den sie aufnimmt, wirklich existiert.
+ *
+ * [zielSchrittId] ist der Schritt, an den das Foto gehoert -- festgehalten beim
+ * Start der Kamera, nicht beim Ruecklauf. Sonst landet ein Foto am betrachteten
+ * Schritt, und der ist nach "Naechstes Teil" fuer einen Moment noch der eben
+ * abgeschlossene.
+ *
+ * [nummer] zaehlt mit, damit zwei aufeinanderfolgende Auftraege unterscheidbar
+ * bleiben, auch wenn sie in dieselbe Millisekunde fallen.
+ */
+@Immutable
+data class KameraAuftrag(
+    val nummer: Int,
+    val zielPfad: String,
+    val zielSchrittId: Long,
+    /** Gesetzt bei "Wiederholen": dieses Foto wird nach der Aufnahme ersetzt. */
+    val ersetztFotoId: Long? = null,
+    /** Diese Kamera-Runde hat den Schritt eroeffnet -- ihr Abbruch nimmt ihn zurueck. */
+    val eroeffnetSchritt: Boolean = false
+)
+
 /** Ein Bottom-Sheet mit Titel, Text und bis zu drei Aktionen. */
 @Immutable
 data class SheetZustand(
@@ -42,6 +69,9 @@ data class BrowserUiState(
     val vollbild: Boolean = false,
     val zeigeWischHinweis: Boolean = true,
     val sheet: SheetZustand? = null,
+
+    /** Nicht null, solange eine Aufnahme aussteht. */
+    val kameraAuftrag: KameraAuftrag? = null,
 
     /** Sekunden des betrachteten Schritts, laufend hochgezaehlt. */
     val schrittSekunden: Long = 0,

--- a/app/src/main/java/com/boltmind/app/feature/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/boltmind/app/feature/browser/BrowserViewModel.kt
@@ -124,7 +124,14 @@ class BrowserViewModel(
 
     // --- Navigation im Browser ------------------------------------------------
 
+    /**
+     * Setzt den betrachteten Schritt. Ein noch offener Sprung wird dabei
+     * aufgegeben: wer selbst navigiert, hat das letzte Wort. Sonst zoege die
+     * naechste Datenmeldung den Mechaniker aus dem Schritt heraus, den er sich
+     * gerade herausgesucht hat.
+     */
     fun onSchrittGewaehlt(index: Int) {
+        folgeSchrittId = null
         _uiState.update {
             it.copy(aktiverIndex = index, aktivesFoto = 0, zeigeWischHinweis = false)
         }
@@ -271,11 +278,17 @@ class BrowserViewModel(
      * Beginnt einen Schritt -- der gemeinsame Weg von "Naechstes Teil" und vom
      * Einstieg ohne offenen Schritt.
      *
-     * Die Reihenfolge ist die Regel: erst existiert der Schritt und ist der
-     * betrachtete, **dann** faehrt die Kamera an (workflow.md, "Reihenfolge beim
-     * Schritt-Start"). Startete die Kamera parallel zur Anlage, kaeme sie in eine
-     * Ansicht zurueck, die noch auf dem eben abgeschlossenen Schritt steht -- das
-     * Foto landete dort, und der grosse Kreis fiele auf "ZURUECK ZU" zurueck.
+     * Die Reihenfolge ist die Regel: der Schritt existiert, **bevor** die Kamera
+     * anfaehrt (workflow.md, "Reihenfolge beim Schritt-Start"). Startete sie
+     * parallel zur Anlage, gaebe es beim Ruecklauf keinen verlaesslichen Schritt,
+     * an den das Foto gehoert.
+     *
+     * Der **betrachtete** Schritt zieht dagegen erst nach, wenn der neue Schritt
+     * ueber den Flow ankommt -- das ist ein eigener Weg ueber [folgeSchrittId] und
+     * [folgeIndex], nicht Teil dieser Funktion. Genau deshalb haelt der
+     * Kamera-Auftrag seine eigene `zielSchrittId` fest, statt sich auf
+     * `aktiverIndex` zu verlassen: der zeigt in diesem Moment noch auf den eben
+     * abgeschlossenen Schritt.
      */
     private fun schrittStarten() {
         val zustand = _uiState.value

--- a/app/src/main/java/com/boltmind/app/feature/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/boltmind/app/feature/browser/BrowserViewModel.kt
@@ -45,14 +45,34 @@ class BrowserViewModel(
         get() = if (modus == BrowserModus.MONTAGE) ReferenzTyp.MONTAGE_SCHRITT
         else ReferenzTyp.DEMONTAGE_SCHRITT
 
+    /**
+     * Der Schritt, auf den die Ansicht springen soll, sobald er in der Liste
+     * auftaucht. Gesetzt beim Schritt-Start, weil der neue Schritt zu diesem
+     * Zeitpunkt schon eine Id hat, aber noch nicht in der beobachteten Liste
+     * steht.
+     */
+    private var folgeSchrittId: Long? = null
+
+    private var auftragsZaehler = 0
+
     init {
         viewModelScope.launch {
             val vorgang = repository.findVorgangById(vorgangId)
             repository.beobachteSchritteMitFotos(vorgangId).collect { alle ->
                 val sortiert = if (modus == BrowserModus.MONTAGE) alle.reversed() else alle
+                var starteSchritt = false
                 _uiState.update { s ->
                     val ersteLadung = s.laedt
-                    val index = if (ersteLadung) startIndex(sortiert) else s.aktiverIndex
+                    // Die Demontage laesst keinen Vorgang ohne offenen Schritt
+                    // zurueck: gibt es keinen, beginnt hier einer -- beim frisch
+                    // aus F-002 uebergebenen Vorgang genauso wie beim
+                    // Wiedereinstieg nach dem Feierabend.
+                    starteSchritt = ersteLadung && modus == BrowserModus.DEMONTAGE &&
+                        sortiert.none { it.schritt.abgeschlossenAm == null }
+                    val index = when {
+                        ersteLadung -> startIndex(sortiert)
+                        else -> folgeIndex(sortiert) ?: s.aktiverIndex
+                    }
                     val neu = s.copy(
                         laedt = false,
                         vorgang = vorgang,
@@ -68,10 +88,24 @@ class BrowserViewModel(
                     // sonst liesse sich der Screen nie verlassen.
                     if (ersteLadung && neu.alleEingebaut) neu.copy(fertig = true) else neu
                 }
+                if (starteSchritt) schrittStarten()
                 zeitAktualisieren()
             }
         }
         starteTicker()
+    }
+
+    /**
+     * Wohin die Ansicht springt, sobald der eben angelegte Schritt in der Liste
+     * ankommt. Danach ist der Sprung erledigt und die Ansicht folgt wieder dem
+     * Mechaniker -- ein Foto, das spaeter eintrifft, zieht sie nicht erneut mit.
+     */
+    private fun folgeIndex(schritte: List<SchrittMitFotos>): Int? {
+        val ziel = folgeSchrittId ?: return null
+        val index = schritte.indexOfFirst { it.schritt.id == ziel }
+        if (index < 0) return null
+        folgeSchrittId = null
+        return index
     }
 
     /**
@@ -214,40 +248,85 @@ class BrowserViewModel(
 
     // --- Kamera und Schritte (Demontage) ---------------------------------------
 
-    /**
-     * Der Pfad, unter dem die System-Kamera gerade schreibt, und wofuer.
-     * Bricht sie ab, raeumt [onKameraAbgebrochen] die leere Huelle weg.
-     */
-    var offeneAufnahme: OffeneAufnahme? = null
-        private set
+    /** Ein weiteres Foto am betrachteten Schritt. */
+    fun onWeiteresFoto() {
+        val schrittId = _uiState.value.aktiverSchritt?.schritt?.id ?: return
+        kameraAnfordern(schrittId)
+    }
 
-    fun aufnahmeAngemeldet(pfad: String, ersetztFotoId: Long?) {
-        offeneAufnahme = OffeneAufnahme(pfad, ersetztFotoId)
+    /**
+     * "Wiederholen" am sichtbaren Foto. Geloescht wird nichts -- gemerkt wird nur,
+     * welches Foto die Aufnahme ersetzen soll (Governance, "Kamera").
+     */
+    fun onWiederholen() {
+        val zustand = _uiState.value
+        val schrittId = zustand.aktiverSchritt?.schritt?.id ?: return
+        val foto = zustand.aktiverSchritt?.fotos?.getOrNull(zustand.aktivesFoto) ?: return
+        kameraAnfordern(schrittId, ersetztFotoId = foto.id)
+    }
+
+    fun onNaechstesTeil() = schrittStarten()
+
+    /**
+     * Beginnt einen Schritt -- der gemeinsame Weg von "Naechstes Teil" und vom
+     * Einstieg ohne offenen Schritt.
+     *
+     * Die Reihenfolge ist die Regel: erst existiert der Schritt und ist der
+     * betrachtete, **dann** faehrt die Kamera an (workflow.md, "Reihenfolge beim
+     * Schritt-Start"). Startete die Kamera parallel zur Anlage, kaeme sie in eine
+     * Ansicht zurueck, die noch auf dem eben abgeschlossenen Schritt steht -- das
+     * Foto landete dort, und der grosse Kreis fiele auf "ZURUECK ZU" zurueck.
+     */
+    private fun schrittStarten() {
+        val zustand = _uiState.value
+        val offen = zustand.offenerIndex?.let { zustand.schritte.getOrNull(it)?.schritt }
+        viewModelScope.launch {
+            val neu = fotos.naechstesTeil(vorgangId, offen)
+            folgeSchrittId = neu.id
+            kameraAnfordern(neu.id, eroeffnetSchritt = true)
+        }
+    }
+
+    private fun kameraAnfordern(
+        zielSchrittId: Long,
+        ersetztFotoId: Long? = null,
+        eroeffnetSchritt: Boolean = false
+    ) {
+        auftragsZaehler++
+        val auftrag = KameraAuftrag(
+            nummer = auftragsZaehler,
+            zielPfad = fotos.neueZieldatei(),
+            zielSchrittId = zielSchrittId,
+            ersetztFotoId = ersetztFotoId,
+            eroeffnetSchritt = eroeffnetSchritt
+        )
+        _uiState.update { it.copy(kameraAuftrag = auftrag) }
     }
 
     fun onFotoAufgenommen() {
-        val aufnahme = offeneAufnahme ?: return
-        offeneAufnahme = null
-        val schrittId = _uiState.value.aktiverSchritt?.schritt?.id ?: return
+        val auftrag = _uiState.value.kameraAuftrag ?: return
+        _uiState.update { it.copy(kameraAuftrag = null) }
         viewModelScope.launch {
-            if (aufnahme.ersetztFotoId != null) {
-                fotos.fotoErsetzen(aufnahme.ersetztFotoId, aufnahme.pfad)
+            if (auftrag.ersetztFotoId != null) {
+                fotos.fotoErsetzen(auftrag.ersetztFotoId, auftrag.zielPfad)
             } else {
-                fotos.fotoUebernehmen(schrittId, aufnahme.pfad)
+                fotos.fotoUebernehmen(auftrag.zielSchrittId, auftrag.zielPfad)
             }
         }
     }
 
-    /** Kamera abgebrochen. Ein vorhandenes Foto bleibt in jedem Fall unangetastet. */
+    /**
+     * Kamera abgebrochen. Ein vorhandenes Foto bleibt in jedem Fall unangetastet;
+     * hat diese Runde den Schritt eroeffnet und blieb er leer, wird der
+     * Schritt-Start zurueckgenommen.
+     */
     fun onKameraAbgebrochen() {
-        offeneAufnahme?.let { fotos.verwerfeDatei(it.pfad) }
-        offeneAufnahme = null
-    }
-
-    fun onNaechstesTeil() {
-        val offen = _uiState.value.offenerIndex
-            ?.let { _uiState.value.schritte.getOrNull(it)?.schritt }
-        viewModelScope.launch { fotos.naechstesTeil(vorgangId, offen) }
+        val auftrag = _uiState.value.kameraAuftrag ?: return
+        _uiState.update { it.copy(kameraAuftrag = null) }
+        viewModelScope.launch {
+            fotos.verwerfeDatei(auftrag.zielPfad)
+            if (auftrag.eroeffnetSchritt) fotos.schrittStartZuruecknehmen(auftrag.zielSchrittId)
+        }
     }
 
     /** Springt vom nachgeschlagenen Schritt zurueck zum offenen. */
@@ -268,9 +347,6 @@ class BrowserViewModel(
     fun onKameraFehltBestaetigt() = _uiState.update { it.copy(kameraFehlt = false) }
 
     fun onNavigationAbgeschlossen() = _uiState.update { it.copy(verlassen = false, fertig = false) }
-
-    /** Eine angemeldete, noch nicht bestaetigte Aufnahme. */
-    data class OffeneAufnahme(val pfad: String, val ersetztFotoId: Long?)
 
     override fun onCleared() {
         ticker?.cancel()

--- a/app/src/main/java/com/boltmind/app/feature/neuervorgang/NeuerVorgangScreen.kt
+++ b/app/src/main/java/com/boltmind/app/feature/neuervorgang/NeuerVorgangScreen.kt
@@ -1,9 +1,6 @@
 package com.boltmind.app.feature.neuervorgang
 
-import android.content.ActivityNotFoundException
 import androidx.activity.compose.BackHandler
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -32,15 +29,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -50,13 +44,13 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.FileProvider
 import coil.compose.AsyncImage
 import com.boltmind.app.R
 import com.boltmind.app.ui.components.BoltMeshHintergrund
 import com.boltmind.app.ui.components.BoltText
 import com.boltmind.app.ui.components.GlasAktion
 import com.boltmind.app.ui.components.GlasFlaeche
+import com.boltmind.app.ui.components.KameraAnbindung
 import com.boltmind.app.ui.components.boltKlick
 import com.boltmind.app.ui.theme.BoltEingabeFlaeche
 import com.boltmind.app.ui.theme.BoltFehler
@@ -141,9 +135,10 @@ fun NeuerVorgangScreen(
     var keineKameraApp by remember { mutableStateOf(false) }
 
     KameraAnbindung(
-        auftrag = uiState.kameraAuftrag,
+        auftragsNummer = uiState.kameraAuftrag?.nummer,
+        zielPfad = uiState.kameraAuftrag?.zielPfad,
         onFotoAufgenommen = onFotoAufgenommen,
-        onKameraAbgebrochen = onKameraAbgebrochen,
+        onAbgebrochen = onKameraAbgebrochen,
         onKeineKameraApp = { keineKameraApp = true }
     )
 
@@ -187,68 +182,6 @@ fun NeuerVorgangScreen(
 
         if (keineKameraApp) {
             KeineKameraHinweis(onSchliessen = onZurueck)
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Kamera
-// ---------------------------------------------------------------------------
-
-/**
- * Haengt die System-Kamera ein: `TakePicture` schreibt ueber den `FileProvider`
- * direkt in die vom ViewModel angelegte Zieldatei. Keine CAMERA-Permission, keine
- * app-eigene Bestaetigung.
- */
-@Composable
-private fun KameraAnbindung(
-    auftrag: KameraAuftrag?,
-    onFotoAufgenommen: (String) -> Unit,
-    onKameraAbgebrochen: () -> Unit,
-    onKeineKameraApp: () -> Unit
-) {
-    val kontext = LocalContext.current
-    val zielPfad by rememberUpdatedState(auftrag?.zielPfad)
-
-    /**
-     * Marke des zuletzt gestarteten Auftrags. Ohne sie wuerde ein
-     * Konfigurationswechsel waehrend der laufenden Aufnahme die Kamera ein zweites
-     * Mal oeffnen -- der Auftrag steht ja noch offen im Zustand.
-     *
-     * Die Marke traegt den Zielpfad und nicht nur die laufende Nummer: der Zaehler
-     * im ViewModel faengt nach einem Prozesstod wieder bei eins an, waehrend diese
-     * Marke den Prozesstod ueberlebt. Ein reiner Zahlenvergleich wuerde die erste
-     * Aufnahme danach stillschweigend verschlucken.
-     */
-    var zuletztGestartet by rememberSaveable { mutableStateOf<String?>(null) }
-
-    val starter = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.TakePicture()
-    ) { erfolgreich ->
-        val pfad = zielPfad
-        if (erfolgreich && pfad != null) onFotoAufgenommen(pfad) else onKameraAbgebrochen()
-    }
-
-    LaunchedEffect(auftrag) {
-        val offen = auftrag ?: return@LaunchedEffect
-        val marke = "${offen.nummer}@${offen.zielPfad}"
-        if (marke == zuletztGestartet) return@LaunchedEffect
-        zuletztGestartet = marke
-        val uri = FileProvider.getUriForFile(
-            kontext,
-            "${kontext.packageName}.fileprovider",
-            File(offen.zielPfad)
-        )
-        try {
-            starter.launch(uri)
-        } catch (_: ActivityNotFoundException) {
-            // Kein Kamera-Programm auf dem Geraet.
-            onKeineKameraApp()
-        } catch (_: SecurityException) {
-            // Deklariert die App die CAMERA-Berechtigung, ohne sie zu halten,
-            // verweigert das System ACTION_IMAGE_CAPTURE. Governance verbietet die
-            // Berechtigung -- der Fang hier haelt trotzdem den Absturz ab.
-            onKeineKameraApp()
         }
     }
 }

--- a/app/src/main/java/com/boltmind/app/feature/neuervorgang/NeuerVorgangViewModel.kt
+++ b/app/src/main/java/com/boltmind/app/feature/neuervorgang/NeuerVorgangViewModel.kt
@@ -96,8 +96,14 @@ class NeuerVorgangViewModel(
     }
 
     /**
-     * "LOS GEHT'S": ohne Auftragsnummer nur die Fehlerzeile, sonst Vorgang und
-     * Schritt 1 anlegen und weiter in die Demontage.
+     * "LOS GEHT'S": ohne Auftragsnummer nur die Fehlerzeile, sonst den Vorgang
+     * anlegen und weiter in die Demontage.
+     *
+     * **Kein Schritt.** Den legt F-003 an, sobald der Browser keinen offenen
+     * Schritt vorfindet -- und startet in derselben Bewegung die Kamera. Legte
+     * F-002 den Schritt hier an, saehe der Browser einen offenen Schritt, hielte
+     * das fuer eine Fortsetzung und zeigte dem Mechaniker eine leere Maske
+     * (F-002 anlegen.md AK 2).
      */
     fun onStartenGetippt() {
         val zustand = _uiState.value
@@ -117,7 +123,6 @@ class NeuerVorgangViewModel(
                     beschreibung = zustand.beschreibung.trim().ifEmpty { null }
                 )
             )
-            repository.schrittAnlegen(vorgangId)
             _uiState.update { it.copy(gestarteterVorgangId = vorgangId, nummerFehlt = false) }
         }
     }

--- a/app/src/main/java/com/boltmind/app/ui/components/KameraAnbindung.kt
+++ b/app/src/main/java/com/boltmind/app/ui/components/KameraAnbindung.kt
@@ -1,0 +1,109 @@
+package com.boltmind.app.ui.components
+
+import android.content.ActivityNotFoundException
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * Haengt die System-Kamera an einen Kamera-Auftrag aus einem ViewModel.
+ *
+ * `TakePicture` schreibt ueber den `FileProvider` direkt in die vom ViewModel
+ * angelegte Zieldatei. Keine CAMERA-Permission, keine app-eigene Bestaetigung --
+ * so verlangt es [docs/specs/governance.md], Abschnitt "Kamera".
+ *
+ * Der Baustein ist bewusst hier und nicht in einem Feature-Paket: F-002 und F-003
+ * brauchen dieselbe Anbindung, und der Waechter unten ist zu leicht zu vergessen,
+ * um ihn ein zweites Mal abzuschreiben. Er nimmt Nummer und Zielpfad einzeln
+ * entgegen statt eines gemeinsamen Auftragstyps -- die beiden Features tragen in
+ * ihren Auftraegen unterschiedliche Zusatzfelder, die hier niemanden angehen.
+ *
+ * @param auftragsNummer laufende Nummer des offenen Auftrags, `null` wenn keiner aussteht
+ * @param zielPfad Datei, in die die Kamera schreiben soll
+ */
+@Composable
+fun KameraAnbindung(
+    auftragsNummer: Int?,
+    zielPfad: String?,
+    onFotoAufgenommen: (String) -> Unit,
+    onAbgebrochen: () -> Unit,
+    onKeineKameraApp: () -> Unit
+) {
+    val aktuellerPfad by rememberUpdatedState(zielPfad)
+    val starter = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture()
+    ) { erfolgreich ->
+        val pfad = aktuellerPfad
+        if (erfolgreich && pfad != null) onFotoAufgenommen(pfad) else onAbgebrochen()
+    }
+
+    val kontext = LocalContext.current
+    KameraAnbindung(
+        auftragsNummer = auftragsNummer,
+        zielPfad = zielPfad,
+        onKeineKameraApp = onKeineKameraApp
+    ) { pfad ->
+        val uri = FileProvider.getUriForFile(
+            kontext,
+            "${kontext.packageName}.fileprovider",
+            File(pfad)
+        )
+        starter.launch(uri)
+    }
+}
+
+/**
+ * Der Waechter ohne echten Launcher -- sichtbar, damit ein Test ihn ohne
+ * Kamera-Activity fahren kann.
+ *
+ * [starte] wird fuer jeden Auftrag **genau einmal** aufgerufen. Ohne diese Sperre
+ * oeffnete ein Konfigurationswechsel waehrend der laufenden Aufnahme die Kamera
+ * ein zweites Mal: der Auftrag steht ja noch offen im ViewModel, das den
+ * Aktivitaetswechsel ueberlebt, waehrend die Komposition neu aufgebaut wird und
+ * der [LaunchedEffect] erneut anlaeuft.
+ *
+ * Die Marke traegt den Zielpfad und nicht nur die laufende Nummer: der Zaehler im
+ * ViewModel faengt nach einem Prozesstod wieder bei eins an, waehrend diese Marke
+ * ueber [rememberSaveable] den Prozesstod ueberlebt. Ein reiner Zahlenvergleich
+ * wuerde die erste Aufnahme danach stillschweigend verschlucken.
+ */
+@Composable
+internal fun KameraAnbindung(
+    auftragsNummer: Int?,
+    zielPfad: String?,
+    onKeineKameraApp: () -> Unit,
+    starte: (String) -> Unit
+) {
+    var zuletztGestartet by rememberSaveable { mutableStateOf<String?>(null) }
+    val marke = if (auftragsNummer != null && zielPfad != null) {
+        "$auftragsNummer@$zielPfad"
+    } else {
+        null
+    }
+
+    LaunchedEffect(marke) {
+        val offen = marke ?: return@LaunchedEffect
+        if (offen == zuletztGestartet) return@LaunchedEffect
+        zuletztGestartet = offen
+        try {
+            starte(checkNotNull(zielPfad))
+        } catch (_: ActivityNotFoundException) {
+            // Kein Kamera-Programm auf dem Geraet.
+            onKeineKameraApp()
+        } catch (_: SecurityException) {
+            // Deklariert die App die CAMERA-Berechtigung, ohne sie zu halten,
+            // verweigert das System ACTION_IMAGE_CAPTURE. Governance verbietet die
+            // Berechtigung -- der Fang hier haelt trotzdem den Absturz ab.
+            onKeineKameraApp()
+        }
+    }
+}

--- a/app/src/main/java/com/boltmind/app/ui/navigation/BrowserRoute.kt
+++ b/app/src/main/java/com/boltmind/app/ui/navigation/BrowserRoute.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.FileProvider
 import com.boltmind.app.R
-import com.boltmind.app.data.foto.FotoManager
 import com.boltmind.app.feature.browser.BrowserScreen
 import com.boltmind.app.feature.browser.BrowserViewModel
 import com.boltmind.app.feature.browser.SheetAktion
@@ -19,7 +18,7 @@ import com.boltmind.app.feature.browser.SheetMarke
 import com.boltmind.app.feature.browser.SheetStil
 import com.boltmind.app.feature.browser.SheetZustand
 import org.koin.androidx.compose.koinViewModel
-import org.koin.compose.koinInject
+import java.io.File
 
 /**
  * Verbindet den Schritt-Browser mit Navigation und System-Kamera.
@@ -33,8 +32,7 @@ fun BrowserRoute(
     onVerlassen: () -> Unit,
     onMontageFertig: () -> Unit = {},
     modifier: Modifier = Modifier,
-    viewModel: BrowserViewModel = koinViewModel(),
-    fotoManager: FotoManager = koinInject()
+    viewModel: BrowserViewModel = koinViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
@@ -43,14 +41,19 @@ fun BrowserRoute(
         if (ok) viewModel.onFotoAufgenommen() else viewModel.onKameraAbgebrochen()
     }
 
-    fun starteKamera(ersetztFotoId: Long?) {
-        val ziel = fotoManager.erstelleZieldatei("schritt")
-        viewModel.aufnahmeAngemeldet(ziel.absolutePath, ersetztFotoId)
+    // Die Kamera startet, was das ViewModel anfordert -- nicht, was ein Tap
+    // ausloest. Nur so steht der Schritt, fuer den aufgenommen wird, sicher schon
+    // in der Datenbank (F-003 workflow.md, "Reihenfolge beim Schritt-Start").
+    // Der Auftrag traegt eine laufende Nummer, damit zwei Auftraege mit demselben
+    // Pfad nicht als derselbe Effekt durchgehen.
+    LaunchedEffect(uiState.kameraAuftrag?.nummer) {
+        val auftrag = uiState.kameraAuftrag ?: return@LaunchedEffect
         val uri = FileProvider.getUriForFile(
-            context, "${context.packageName}.fileprovider", ziel
+            context, "${context.packageName}.fileprovider", File(auftrag.zielPfad)
         )
         runCatching { kamera.launch(uri) }.onFailure {
-            // Kein Kamera-Programm auf dem Geraet: die leere Huelle wieder wegraeumen.
+            // Kein Kamera-Programm auf dem Geraet: der Abbruch raeumt die leere
+            // Huelle weg und nimmt einen eben eroeffneten Schritt zurueck.
             viewModel.onKameraAbgebrochen()
         }
     }
@@ -87,14 +90,11 @@ fun BrowserRoute(
         onVollbildSchliessen = viewModel::onVollbildSchliessen,
         onLabelUmgeschaltet = viewModel::onLabelUmgeschaltet,
         onTimerUmgeschaltet = viewModel::onTimerUmgeschaltet,
-        onNaechstesTeil = {
-            viewModel.onNaechstesTeil()
-            starteKamera(null)
-        },
-        onWeiteresFoto = { starteKamera(null) },
+        onNaechstesTeil = viewModel::onNaechstesTeil,
+        onWeiteresFoto = viewModel::onWeiteresFoto,
         // Wiederholen: erst die Kamera, das alte Foto verschwindet erst nach
         // bestaetigter Neuaufnahme (Governance).
-        onWiederholen = { starteKamera(uiState.aktiverSchritt?.fotos?.getOrNull(uiState.aktivesFoto)?.id) },
+        onWiederholen = viewModel::onWiederholen,
         onZumOffenenSchritt = viewModel::onZumOffenenSchritt,
         onEingebaut = viewModel::onEingebaut,
         onHaekchenAnfragen = {

--- a/app/src/main/java/com/boltmind/app/ui/navigation/BrowserRoute.kt
+++ b/app/src/main/java/com/boltmind/app/ui/navigation/BrowserRoute.kt
@@ -1,15 +1,11 @@
 package com.boltmind.app.ui.navigation
 
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.core.content.FileProvider
 import com.boltmind.app.R
 import com.boltmind.app.feature.browser.BrowserScreen
 import com.boltmind.app.feature.browser.BrowserViewModel
@@ -17,15 +13,15 @@ import com.boltmind.app.feature.browser.SheetAktion
 import com.boltmind.app.feature.browser.SheetMarke
 import com.boltmind.app.feature.browser.SheetStil
 import com.boltmind.app.feature.browser.SheetZustand
+import com.boltmind.app.ui.components.KameraAnbindung
 import org.koin.androidx.compose.koinViewModel
-import java.io.File
 
 /**
  * Verbindet den Schritt-Browser mit Navigation und System-Kamera.
  *
- * Die Kamera laeuft ueber [ActivityResultContracts.TakePicture] und schreibt
- * direkt in die Zieldatei unter `photos/`. Es gibt kein temp-Verzeichnis und
- * keine app-eigene Bestaetigung -- die System-Kamera bestaetigt selbst.
+ * Die Kamera haengt an [KameraAnbindung] und schreibt direkt in die Zieldatei
+ * unter `photos/`. Es gibt kein temp-Verzeichnis und keine app-eigene
+ * Bestaetigung -- die System-Kamera bestaetigt selbst.
  */
 @Composable
 fun BrowserRoute(
@@ -35,28 +31,20 @@ fun BrowserRoute(
     viewModel: BrowserViewModel = koinViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val context = LocalContext.current
-
-    val kamera = rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { ok ->
-        if (ok) viewModel.onFotoAufgenommen() else viewModel.onKameraAbgebrochen()
-    }
 
     // Die Kamera startet, was das ViewModel anfordert -- nicht, was ein Tap
     // ausloest. Nur so steht der Schritt, fuer den aufgenommen wird, sicher schon
     // in der Datenbank (F-003 workflow.md, "Reihenfolge beim Schritt-Start").
-    // Der Auftrag traegt eine laufende Nummer, damit zwei Auftraege mit demselben
-    // Pfad nicht als derselbe Effekt durchgehen.
-    LaunchedEffect(uiState.kameraAuftrag?.nummer) {
-        val auftrag = uiState.kameraAuftrag ?: return@LaunchedEffect
-        val uri = FileProvider.getUriForFile(
-            context, "${context.packageName}.fileprovider", File(auftrag.zielPfad)
-        )
-        runCatching { kamera.launch(uri) }.onFailure {
-            // Kein Kamera-Programm auf dem Geraet: der Abbruch raeumt die leere
-            // Huelle weg und nimmt einen eben eroeffneten Schritt zurueck.
-            viewModel.onKameraAbgebrochen()
-        }
-    }
+    KameraAnbindung(
+        auftragsNummer = uiState.kameraAuftrag?.nummer,
+        zielPfad = uiState.kameraAuftrag?.zielPfad,
+        onFotoAufgenommen = { viewModel.onFotoAufgenommen() },
+        onAbgebrochen = viewModel::onKameraAbgebrochen,
+        // Kein Kamera-Programm auf dem Geraet: derselbe Weg wie ein Abbruch --
+        // die leere Huelle verschwindet, ein eben eroeffneter Schritt wird
+        // zurueckgenommen.
+        onKeineKameraApp = viewModel::onKameraAbgebrochen
+    )
 
     LaunchedEffect(uiState.fertig) {
         if (uiState.fertig) {

--- a/app/src/main/res/values/strings_browser_aktionen.xml
+++ b/app/src/main/res/values/strings_browser_aktionen.xml
@@ -8,7 +8,7 @@
     <string name="archiv_nur_lesen">ARCHIV · NUR LESEN</string>
 
     <!-- Aktionskreise -->
-    <string name="browser_naechstes">NÄCHSTES</string>
+    <string name="browser_naechstes">NÄCHSTES TEIL</string>
     <string name="browser_weiteres_foto">NOCH\'N FOTO</string>
     <string name="browser_zurueck">ZURÜCK</string>
     <string name="browser_zurueck_zu_schritt">ZURÜCK ZU</string>

--- a/app/src/test/java/com/boltmind/app/data/repository/ReparaturRepositoryTest.kt
+++ b/app/src/test/java/com/boltmind/app/data/repository/ReparaturRepositoryTest.kt
@@ -605,6 +605,7 @@ class ReparaturRepositoryTest {
             listOf(
                 eintrag("schrittAnlegen") { it.schrittAnlegen(VORGANG_ID) },
                 eintrag("schrittAbschliessen") { it.schrittAbschliessen(SCHRITT_ID) },
+                eintrag("schrittWiederOeffnen") { it.schrittWiederOeffnen(SCHRITT_ID) },
                 eintrag("schrittVerwerfen") { it.schrittVerwerfen(SCHRITT_ID) },
                 eintrag("setzeEingebaut") { it.setzeEingebaut(SCHRITT_ID, eingebaut = true) },
                 eintrag("fotoAnhaengen") { it.fotoAnhaengen(SCHRITT_ID, "/photos/neu.jpg") },

--- a/app/src/test/java/com/boltmind/app/feature/browser/BrowserFotoSteuerungTest.kt
+++ b/app/src/test/java/com/boltmind/app/feature/browser/BrowserFotoSteuerungTest.kt
@@ -7,6 +7,8 @@ import com.boltmind.app.data.repository.ReparaturRepository
 import com.boltmind.app.service.zeiterfassung.ReferenzTyp
 import com.boltmind.app.service.zeiterfassung.ZeiterfassungService
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -46,6 +48,7 @@ class BrowserFotoSteuerungTest {
 
     private companion object {
         const val SCHRITT_ID = 42L
+        const val FRISCHER_ID = 99L
         const val ALTES_FOTO_ID = 7L
         const val NEUER_PFAD = "/photos/schritt_neu.jpg"
         const val ALTER_PFAD = "/photos/schritt_alt.jpg"
@@ -187,6 +190,104 @@ class BrowserFotoSteuerungTest {
             // Then: nichts abzuschliessen, aber die Messung laeuft an
             verify(repository, never()).schrittAbschliessen(any())
             verify(zeiterfassung).starten(99L, ReferenzTyp.DEMONTAGE_SCHRITT)
+        }
+    }
+
+    /**
+     * Bricht die Kamera ab, die einen Schritt gerade erst eroeffnet hat, wird der
+     * Schritt-Start vollstaendig zurueckgenommen (workflow.md, "Rollback beim
+     * Abbruch am frischen Schritt").
+     *
+     * Der zweite Teil -- den Vorgaenger wieder zu oeffnen -- ist der wichtigere.
+     * Bliebe er abgeschlossen, haette der Vorgang danach **keinen** offenen
+     * Schritt mehr: der grosse Kreis zeigte "ZURUECK ZU" ins Leere und der
+     * Mechaniker kaeme nicht mehr weiter. Genau diese Sackgasse (#121) schliesst
+     * die Invariante aus, dass die Demontage immer genau einen offenen Schritt hat.
+     */
+    @Nested
+    @DisplayName("Rollback beim Abbruch am frischen Schritt")
+    inner class Rollback {
+
+        private val vorgaenger = Schritt(
+            id = SCHRITT_ID,
+            reparaturvorgangId = 1L,
+            schrittNummer = 4,
+            gestartetAm = T0,
+            abgeschlossenAm = T0.plusSeconds(60)
+        )
+
+        private val frischer = Schritt(
+            id = FRISCHER_ID,
+            reparaturvorgangId = 1L,
+            schrittNummer = 5,
+            gestartetAm = T0.plusSeconds(60)
+        )
+
+        @BeforeEach
+        fun gegeben() {
+            repository.stub {
+                onBlocking { findSchritt(FRISCHER_ID) } doReturn frischer
+                onBlocking { holeSchritte(1L) } doReturn listOf(vorgaenger, frischer)
+                onBlocking { holeFotos(FRISCHER_ID) } doReturn emptyList()
+            }
+        }
+
+        @Test
+        fun `loescht den fotolosen Schritt und oeffnet den Vorgaenger wieder`() = runTest {
+            // When: die Kamera, die Schritt 5 eroeffnet hat, bricht ab
+            val zurueckgerollt = steuerung.schrittStartZuruecknehmen(FRISCHER_ID)
+
+            // Then: Schritt 5 ist weg, Schritt 4 wieder offen -- die exakte
+            // Umkehrung des Schritt-Starts, inklusive der Zeitmessung
+            assertTrue(zurueckgerollt)
+            inOrder(repository, zeiterfassung) {
+                verify(zeiterfassung).stoppeFallsLaeuft(FRISCHER_ID, ReferenzTyp.DEMONTAGE_SCHRITT)
+                verify(repository).schrittVerwerfen(FRISCHER_ID)
+                verify(repository).schrittWiederOeffnen(SCHRITT_ID)
+                verify(zeiterfassung).starten(SCHRITT_ID, ReferenzTyp.DEMONTAGE_SCHRITT)
+            }
+        }
+
+        @Test
+        fun `laesst einen Schritt mit Fotos unangetastet`() = runTest {
+            // Given: der Mechaniker hat in dieser Runde bereits ein Foto gemacht
+            repository.stub { onBlocking { holeFotos(FRISCHER_ID) } doReturn listOf(ALTES_FOTO) }
+
+            // When: die Kamera bricht ab
+            val zurueckgerollt = steuerung.schrittStartZuruecknehmen(FRISCHER_ID)
+
+            // Then: nichts wird verworfen -- ein dokumentierter Schritt bleibt
+            assertFalse(zurueckgerollt)
+            verify(repository, never()).schrittVerwerfen(any())
+            verify(repository, never()).schrittWiederOeffnen(any())
+        }
+
+        @Test
+        fun `laesst den ersten Schritt stehen, wenn es keinen Vorgaenger gibt`() = runTest {
+            // Given: Schritt 1 eines frisch angelegten Vorgangs
+            repository.stub { onBlocking { holeSchritte(1L) } doReturn listOf(frischer) }
+
+            // When: die Kamera bricht ab
+            val zurueckgerollt = steuerung.schrittStartZuruecknehmen(FRISCHER_ID)
+
+            // Then: es gibt kein Ziel, auf das zurueckgerollt werden koennte.
+            // Der Schritt bleibt offen und leer -- "Beenden" verwirft ihn spaeter
+            assertFalse(zurueckgerollt)
+            verify(repository, never()).schrittVerwerfen(any())
+            verify(repository, never()).schrittWiederOeffnen(any())
+        }
+
+        @Test
+        fun `meldet nichts zurueck, wenn der Schritt gar nicht mehr existiert`() = runTest {
+            // Given: die Zeile ist zwischenzeitlich verschwunden
+            repository.stub { onBlocking { findSchritt(FRISCHER_ID) } doReturn null }
+
+            // When: die Kamera bricht ab
+            val zurueckgerollt = steuerung.schrittStartZuruecknehmen(FRISCHER_ID)
+
+            // Then: nichts zu tun, kein Absturz
+            assertFalse(zurueckgerollt)
+            verify(repository, never()).schrittVerwerfen(any())
         }
     }
 

--- a/app/src/test/java/com/boltmind/app/feature/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/boltmind/app/feature/browser/BrowserViewModelTest.kt
@@ -439,6 +439,32 @@ class BrowserViewModelTest {
         }
 
         @Test
+        fun `gibt den Sprung auf, sobald der Mechaniker selbst navigiert`() {
+            // Given: "Naechstes Teil" ist getippt, Schritt 3 also angelegt und als
+            // Sprungziel gemerkt -- die Liste kennt ihn aber noch nicht
+            neuerSchrittIst(3)
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1), schritt(2, offen = true))
+            )
+            browser.onNaechstesTeil()
+            abarbeiten()
+
+            // When: der Mechaniker schlaegt in dem Moment Schritt 1 nach, danach
+            // meldet der Flow den neuen Schritt nach
+            browser.onSchrittGewaehlt(0)
+            abarbeiten()
+            schritteFlow.value = listOf(schritt(1), schritt(2), schritt(3, offen = true))
+            abarbeiten()
+
+            // Then: die Ansicht bleibt, wo der Mechaniker sie hingestellt hat.
+            // Ein gemerkter Sprung darf ihn nicht nachtraeglich wegziehen -- das
+            // ist dieselbe Regel wie "haelt den betrachteten Schritt fest"
+            assertEquals(0, browser.uiState.value.aktiverIndex)
+            assertEquals(1, browser.uiState.value.aktiverSchritt?.schritt?.schrittNummer)
+        }
+
+        @Test
         fun `zielt mit der Kamera auf den neuen Schritt, nicht auf den verlassenen`() {
             // Given: Schritt 2 ist offen
             neuerSchrittIst(3)

--- a/app/src/test/java/com/boltmind/app/feature/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/boltmind/app/feature/browser/BrowserViewModelTest.kt
@@ -27,11 +27,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.verifyBlocking
-import org.mockito.kotlin.verifyNoInteractions
 import java.time.Duration
 import java.time.Instant
 
@@ -76,7 +77,15 @@ class BrowserViewModelTest {
             onBlocking { gesamtdauer(any(), any()) } doReturn Duration.ZERO
             onBlocking { laeuft(any(), any()) } doReturn false
         }
-        fotoSteuerung = mock()
+        fotoSteuerung = mock {
+            on { neueZieldatei() } doReturn ZIEL_PFAD
+            onBlocking { naechstesTeil(any(), anyOrNull()) } doReturn schritt(1).schritt
+        }
+    }
+
+    /** Legt fest, welchen Schritt die naechste Anlage liefert. */
+    private fun neuerSchrittIst(nummer: Int) = fotoSteuerung.stub {
+        onBlocking { naechstesTeil(any(), anyOrNull()) } doReturn schritt(nummer).schritt
     }
 
     @AfterEach
@@ -108,20 +117,25 @@ class BrowserViewModelTest {
         }
 
         @Test
-        fun `landet auf dem letzten Schritt, wenn keiner mehr offen ist`() {
-            // Given: alle Schritte sind abgeschlossen (nach "Beenden" wieder geoeffnet)
+        fun `folgt dem Schritt, den der Einstieg ohne offenen Schritt anlegt`() {
+            // Given: alle Schritte sind abgeschlossen, der Einstieg legt Schritt 4 an
+            neuerSchrittIst(4)
             val browser = browserFuer(
                 BrowserModus.DEMONTAGE,
                 listOf(schritt(1), schritt(2), schritt(3))
             )
 
-            // When: der Browser oeffnet
-            val zustand = browser.uiState.value
+            // When: der Flow meldet den neuen Schritt nach
+            schritteFlow.value =
+                listOf(schritt(1), schritt(2), schritt(3), schritt(4, offen = true))
+            abarbeiten()
 
-            // Then: der letzte Schritt -- und er gilt nicht als offener Schritt
-            assertEquals(3, zustand.aktiverSchritt?.schritt?.schrittNummer)
-            assertNull(zustand.offenerIndex)
-            assertFalse(zustand.betrachtetOffenenSchritt)
+            // Then: die Ansicht steht auf dem neuen Schritt, nicht auf dem letzten
+            // abgeschlossenen. Frueher blieb sie dort haengen -- ohne offenen
+            // Schritt zeigte der grosse Kreis "ZURUECK ZU 00" ins Leere (#121)
+            val zustand = browser.uiState.value
+            assertEquals(4, zustand.aktiverSchritt?.schritt?.schrittNummer)
+            assertTrue(zustand.betrachtetOffenenSchritt)
         }
 
         @Test
@@ -293,8 +307,15 @@ class BrowserViewModelTest {
 
         @Test
         fun `reicht beim Beenden ohne offenen Schritt kein Ziel weiter`() {
-            // Given: alle Schritte sind abgeschlossen
-            val browser = browserFuer(BrowserModus.DEMONTAGE, listOf(schritt(1), schritt(2)))
+            // Given: der offene Schritt verschwindet unter der Ansicht. Ueber den
+            // Einstieg ist dieser Zustand nicht mehr erreichbar -- der legt sofort
+            // einen Schritt an --, ueber eine Datenmeldung schon
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1), schritt(2, offen = true))
+            )
+            schritteFlow.value = listOf(schritt(1), schritt(2))
+            abarbeiten()
 
             // When: Feierabend
             browser.onFeierabendBestaetigt()
@@ -323,6 +344,210 @@ class BrowserViewModelTest {
             assertEquals(3, zustand.aktiverSchritt?.schritt?.schrittNummer)
             assertEquals(1, zustand.offenerIndex)
             assertFalse(zustand.betrachtetOffenenSchritt)
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Der Schritt beginnt mit der Kamera
+    // ------------------------------------------------------------------
+
+    /**
+     * Ein Schritt beginnt nie mit einer leeren Maske, sondern mit der Kamera --
+     * beim Einstieg ohne offenen Schritt und bei "Naechstes Teil"
+     * (schritt-ansicht.md AK 1b und US-003.2 AK 2).
+     *
+     * Die Reihenfolge ist dabei die eigentliche Regel: erst existiert der
+     * Schritt und ist der betrachtete, **dann** faehrt die Kamera an. Wer beides
+     * parallel ausloest, bekommt eine Kamera, die in eine Ansicht zurueckkehrt,
+     * welche noch auf dem eben abgeschlossenen Schritt steht.
+     */
+    @Nested
+    inner class `US-003_1 Der Schritt beginnt mit der Kamera` {
+
+        @Test
+        fun `legt beim leeren Vorgang einen Schritt an und fordert die Kamera an`() {
+            // Given/When: ein frisch aus F-002 uebergebener Vorgang ohne Schritte
+            neuerSchrittIst(1)
+            val browser = browserFuer(BrowserModus.DEMONTAGE, emptyList())
+
+            // Then: Schritt 1 entsteht hier, nicht in F-002, und die Kamera faehrt an
+            verifyBlocking(fotoSteuerung) { naechstesTeil(VORGANG_ID, null) }
+            val auftrag = browser.uiState.value.kameraAuftrag
+            assertNotNull(auftrag)
+            assertEquals(SCHRITT_ID_1, auftrag!!.zielSchrittId)
+            assertTrue(auftrag.eroeffnetSchritt)
+        }
+
+        @Test
+        fun `startet beim Wiedereinstieg nach Feierabend einen neuen Schritt`() {
+            // Given/When: alle Schritte sind abgeschlossen, der Mechaniker macht weiter
+            neuerSchrittIst(3)
+            val browser = browserFuer(BrowserModus.DEMONTAGE, listOf(schritt(1), schritt(2)))
+
+            // Then: kein Nachschlage-Zustand ohne Weg nach vorn (#121), sondern
+            // ein neuer Schritt mit laufender Kamera
+            verifyBlocking(fotoSteuerung) { naechstesTeil(VORGANG_ID, null) }
+            assertEquals(SCHRITT_ID_3, browser.uiState.value.kameraAuftrag?.zielSchrittId)
+        }
+
+        @Test
+        fun `laesst einen offenen Schritt in Ruhe und fordert keine Kamera an`() {
+            // Given/When: der Mechaniker setzt auf seinem offenen Schritt auf
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1), schritt(2, offen = true))
+            )
+
+            // Then: fortsetzen heisst fortsetzen -- keine Anlage, keine Kamera (AK 1)
+            verifyBlocking(fotoSteuerung, never()) { naechstesTeil(any(), any()) }
+            assertNull(browser.uiState.value.kameraAuftrag)
+        }
+
+        @Test
+        fun `ruehrt Montage und Archiv nicht an`() {
+            // Given/When: beide lesen nur -- auch ohne offenen Schritt
+            val montage = browserFuer(BrowserModus.MONTAGE, listOf(schritt(1), schritt(2)))
+            val archiv = browserFuer(BrowserModus.ARCHIV, listOf(schritt(1), schritt(2)))
+
+            // Then: eine lesende Betriebsart legt niemals einen Schritt an
+            verifyBlocking(fotoSteuerung, never()) { naechstesTeil(any(), any()) }
+            assertNull(montage.uiState.value.kameraAuftrag)
+            assertNull(archiv.uiState.value.kameraAuftrag)
+        }
+
+        @Test
+        fun `laesst die Ansicht dem neuen Schritt folgen`() {
+            // Given: Schritt 2 ist offen und wird betrachtet
+            neuerSchrittIst(3)
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1), schritt(2, offen = true))
+            )
+
+            // When: "Naechstes Teil", danach meldet der Flow die neue Liste nach
+            browser.onNaechstesTeil()
+            abarbeiten()
+            schritteFlow.value = listOf(schritt(1), schritt(2), schritt(3, offen = true))
+            abarbeiten()
+
+            // Then: die Ansicht steht auf dem neuen Schritt. Bliebe sie stehen,
+            // waere der betrachtete Schritt der eben abgeschlossene und der
+            // grosse Kreis fiele auf "ZURUECK ZU" zurueck
+            val zustand = browser.uiState.value
+            assertEquals(3, zustand.aktiverSchritt?.schritt?.schrittNummer)
+            assertTrue(zustand.betrachtetOffenenSchritt)
+        }
+
+        @Test
+        fun `zielt mit der Kamera auf den neuen Schritt, nicht auf den verlassenen`() {
+            // Given: Schritt 2 ist offen
+            neuerSchrittIst(3)
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1), schritt(2, offen = true))
+            )
+
+            // When: "Naechstes Teil"
+            browser.onNaechstesTeil()
+            abarbeiten()
+
+            // Then: der Auftrag traegt die Id des neuen Schritts
+            val auftrag = browser.uiState.value.kameraAuftrag
+            assertNotNull(auftrag)
+            assertEquals(SCHRITT_ID_3, auftrag!!.zielSchrittId)
+            assertTrue(auftrag.eroeffnetSchritt)
+            assertNull(auftrag.ersetztFotoId)
+        }
+
+        @Test
+        fun `haengt das Foto an den Ziel-Schritt, auch wenn der Flow noch nicht nachgezogen hat`() {
+            // Given: "Naechstes Teil" ist getippt, die Liste kennt Schritt 3 noch nicht
+            neuerSchrittIst(3)
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1), schritt(2, offen = true))
+            )
+            browser.onNaechstesTeil()
+            abarbeiten()
+
+            // When: die System-Kamera bestaetigt
+            browser.onFotoAufgenommen()
+            abarbeiten()
+
+            // Then: das Foto haengt am Ziel des Auftrags. Waere der betrachtete
+            // Schritt massgeblich, landete es am eben abgeschlossenen Schritt 2
+            verifyBlocking(fotoSteuerung) { fotoUebernehmen(SCHRITT_ID_3, ZIEL_PFAD) }
+            verifyBlocking(fotoSteuerung, never()) { fotoUebernehmen(SCHRITT_ID_2, ZIEL_PFAD) }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Rollback
+    // ------------------------------------------------------------------
+
+    @Nested
+    inner class `US-003_4 Abbruch am frischen Schritt rollt zurueck` {
+
+        @Test
+        fun `nimmt den Schritt-Start zurueck, wenn die eroeffnende Kamera abbricht`() {
+            // Given: "Naechstes Teil" hat Schritt 3 eroeffnet
+            neuerSchrittIst(3)
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1), schritt(2, offen = true))
+            )
+            browser.onNaechstesTeil()
+            abarbeiten()
+
+            // When: der Mechaniker bricht die Kamera ab
+            browser.onKameraAbgebrochen()
+            abarbeiten()
+
+            // Then: leere Datei weg -- und der Schritt-Start zurueckgenommen
+            verifyBlocking(fotoSteuerung) { verwerfeDatei(ZIEL_PFAD) }
+            verifyBlocking(fotoSteuerung) { schrittStartZuruecknehmen(SCHRITT_ID_3) }
+        }
+
+        @Test
+        fun `laesst den Schritt stehen, wenn die Kamera aus Noch'n Foto kam`() {
+            // Given: der Mechaniker haengt ein weiteres Foto an seinen offenen Schritt
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(2, offen = true, fotos = listOf(foto(1))))
+            )
+            browser.onWeiteresFoto()
+            abarbeiten()
+
+            // When: er bricht ab
+            browser.onKameraAbgebrochen()
+            abarbeiten()
+
+            // Then: nur die leere Huelle verschwindet. Diese Kamera hat keinen
+            // Schritt eroeffnet, also gibt es auch nichts zurueckzunehmen
+            verifyBlocking(fotoSteuerung) { verwerfeDatei(ZIEL_PFAD) }
+            verifyBlocking(fotoSteuerung, never()) { schrittStartZuruecknehmen(any()) }
+        }
+
+        @Test
+        fun `nimmt nach einer geglueckten Aufnahme nichts mehr zurueck`() {
+            // Given: die eroeffnende Kamera hat geliefert
+            neuerSchrittIst(3)
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1), schritt(2, offen = true))
+            )
+            browser.onNaechstesTeil()
+            abarbeiten()
+            browser.onFotoAufgenommen()
+            abarbeiten()
+
+            // When: doch noch eine Abbruchmeldung eintrudelt
+            browser.onKameraAbgebrochen()
+            abarbeiten()
+
+            // Then: der Auftrag ist erledigt, der Schritt bleibt bestehen
+            assertNull(browser.uiState.value.kameraAuftrag)
+            verifyBlocking(fotoSteuerung, never()) { schrittStartZuruecknehmen(any()) }
         }
     }
 
@@ -655,16 +880,20 @@ class BrowserViewModelTest {
 
         @Test
         fun `raeumt nur die leere Zieldatei weg und laesst das vorhandene Foto stehen`() {
-            // Given: "Wiederholen" wurde fuer das vorhandene Foto 42 gestartet
-            val browser = browserFuer(BrowserModus.DEMONTAGE, listOf(schritt(1, offen = true)))
-            browser.aufnahmeAngemeldet(NEUER_PFAD, ersetztFotoId = 42)
+            // Given: "Wiederholen" wurde fuer das sichtbare Foto gestartet
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1, offen = true, fotos = listOf(foto(42))))
+            )
+            browser.onWiederholen()
+            abarbeiten()
 
             // When: die System-Kamera bricht ab
             browser.onKameraAbgebrochen()
             abarbeiten()
 
             // Then: nur die leere Huelle verschwindet, das alte Foto bleibt unberuehrt
-            verifyBlocking(fotoSteuerung) { verwerfeDatei(NEUER_PFAD) }
+            verifyBlocking(fotoSteuerung) { verwerfeDatei(ZIEL_PFAD) }
             verifyBlocking(fotoSteuerung, never()) { fotoErsetzen(any(), any()) }
             verifyBlocking(fotoSteuerung, never()) { fotoUebernehmen(any(), any()) }
         }
@@ -672,8 +901,12 @@ class BrowserViewModelTest {
         @Test
         fun `ignoriert eine nachtraegliche Erfolgsmeldung nach dem Abbruch`() {
             // Given: die Aufnahme wurde bereits abgebrochen
-            val browser = browserFuer(BrowserModus.DEMONTAGE, listOf(schritt(1, offen = true)))
-            browser.aufnahmeAngemeldet(NEUER_PFAD, ersetztFotoId = 42)
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1, offen = true, fotos = listOf(foto(42))))
+            )
+            browser.onWiederholen()
+            abarbeiten()
             browser.onKameraAbgebrochen()
             abarbeiten()
 
@@ -682,7 +915,7 @@ class BrowserViewModelTest {
             abarbeiten()
 
             // Then: nichts wird ersetzt oder angehaengt
-            assertNull(browser.offeneAufnahme)
+            assertNull(browser.uiState.value.kameraAuftrag)
             verifyBlocking(fotoSteuerung, never()) { fotoErsetzen(any(), any()) }
             verifyBlocking(fotoSteuerung, never()) { fotoUebernehmen(any(), any()) }
         }
@@ -696,8 +929,9 @@ class BrowserViewModelTest {
             browser.onKameraAbgebrochen()
             abarbeiten()
 
-            // Then: keine Datei wird geloescht
-            verifyNoInteractions(fotoSteuerung)
+            // Then: keine Datei wird geloescht und kein Schritt zurueckgenommen
+            verifyBlocking(fotoSteuerung, never()) { verwerfeDatei(any()) }
+            verifyBlocking(fotoSteuerung, never()) { schrittStartZuruecknehmen(any()) }
         }
 
         @Test
@@ -707,23 +941,28 @@ class BrowserViewModelTest {
                 BrowserModus.DEMONTAGE,
                 listOf(schritt(1), schritt(2, offen = true))
             )
-            browser.aufnahmeAngemeldet(NEUER_PFAD, ersetztFotoId = null)
+            browser.onWeiteresFoto()
+            abarbeiten()
 
             // When: die System-Kamera bestaetigt
             browser.onFotoAufgenommen()
             abarbeiten()
 
             // Then: das Foto haengt am betrachteten Schritt, nichts wird ersetzt
-            verifyBlocking(fotoSteuerung) { fotoUebernehmen(SCHRITT_ID_2, NEUER_PFAD) }
+            verifyBlocking(fotoSteuerung) { fotoUebernehmen(SCHRITT_ID_2, ZIEL_PFAD) }
             verifyBlocking(fotoSteuerung, never()) { fotoErsetzen(any(), any()) }
-            assertNull(browser.offeneAufnahme)
+            assertNull(browser.uiState.value.kameraAuftrag)
         }
 
         @Test
         fun `ersetzt das alte Foto erst nach bestaetigter Neuaufnahme`() {
-            // Given: "Wiederholen" fuer Foto 42 ist angemeldet
-            val browser = browserFuer(BrowserModus.DEMONTAGE, listOf(schritt(1, offen = true)))
-            browser.aufnahmeAngemeldet(NEUER_PFAD, ersetztFotoId = 42)
+            // Given: "Wiederholen" fuer das sichtbare Foto 42 laeuft
+            val browser = browserFuer(
+                BrowserModus.DEMONTAGE,
+                listOf(schritt(1, offen = true, fotos = listOf(foto(42))))
+            )
+            browser.onWiederholen()
+            abarbeiten()
             verifyBlocking(fotoSteuerung, never()) { fotoErsetzen(any(), any()) }
 
             // When: die System-Kamera bestaetigt
@@ -731,7 +970,7 @@ class BrowserViewModelTest {
             abarbeiten()
 
             // Then: jetzt erst wird ersetzt, und nichts angehaengt
-            verifyBlocking(fotoSteuerung) { fotoErsetzen(42, NEUER_PFAD) }
+            verifyBlocking(fotoSteuerung) { fotoErsetzen(42, ZIEL_PFAD) }
             verifyBlocking(fotoSteuerung, never()) { fotoUebernehmen(any(), any()) }
         }
     }
@@ -952,9 +1191,12 @@ class BrowserViewModelTest {
 
     private companion object {
         const val VORGANG_ID = 4L
-        const val NEUER_PFAD = "/photos/schritt_neu.jpg"
+
+        /** Was [BrowserFotoSteuerung.neueZieldatei] im Test liefert. */
+        const val ZIEL_PFAD = "/photos/schritt_ziel.jpg"
 
         /** [schritt] vergibt die ID als Schrittnummer mal zehn. */
+        const val SCHRITT_ID_1 = 10L
         const val SCHRITT_ID_2 = 20L
         const val SCHRITT_ID_3 = 30L
 

--- a/app/src/test/java/com/boltmind/app/feature/neuervorgang/NeuerVorgangViewModelTest.kt
+++ b/app/src/test/java/com/boltmind/app/feature/neuervorgang/NeuerVorgangViewModelTest.kt
@@ -1,0 +1,117 @@
+package com.boltmind.app.feature.neuervorgang
+
+import com.boltmind.app.data.foto.FotoManager
+import com.boltmind.app.data.repository.ReparaturRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+import java.io.File
+
+/**
+ * Tests fuer den Anlage-Flow (F-002).
+ *
+ * Hier steht bewusst eine **Negativ**-Aussage im Mittelpunkt: "LOS GEHT'S" legt
+ * keinen Schritt an. Das sieht nach einer Nichtigkeit aus, ist aber die Naht
+ * zwischen F-002 und F-003. Legte F-002 Schritt 1 selbst an, faende der Browser
+ * einen offenen Schritt vor, hielte das fuer eine Fortsetzung und zeigte dem
+ * Mechaniker statt der Kamera eine leere Maske -- genau der Fehler, den
+ * `anlegen.md` AK 2 seit dem 2026-08-01 ausschliesst.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NeuerVorgangViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private lateinit var repository: ReparaturRepository
+    private lateinit var fotoManager: FotoManager
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        repository = mock {
+            onBlocking { erstelleVorgang(any()) } doReturn VORGANG_ID
+        }
+        fotoManager = mock {
+            on { erstelleZieldatei(any()) } doReturn File(ZIEL_PFAD)
+        }
+    }
+
+    @AfterEach
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Nested
+    inner class `US-002_2 AK 2 Los geht's uebergibt an die Demontage` {
+
+        @Test
+        fun `legt den Vorgang an, aber keinen Schritt`() = runTest(dispatcher) {
+            // Given: ein ausgefuelltes Formular
+            val anlage = anlegen()
+            anlage.onAuftragsnummerGeaendert("2026-0815")
+
+            // When: "LOS GEHT'S"
+            anlage.onStartenGetippt()
+            testScheduler.runCurrent()
+
+            // Then: der Vorgang steht, der Schritt gehoert F-003
+            verifyBlocking(repository) { erstelleVorgang(any()) }
+            verifyBlocking(repository, never()) { schrittAnlegen(any()) }
+            assertEquals(VORGANG_ID, anlage.uiState.value.gestarteterVorgangId)
+        }
+
+        @Test
+        fun `legt ohne Auftragsnummer weder Vorgang noch Schritt an`() = runTest(dispatcher) {
+            // Given: das Nummernfeld ist leer
+            val anlage = anlegen()
+
+            // When: "LOS GEHT'S"
+            anlage.onStartenGetippt()
+            testScheduler.runCurrent()
+
+            // Then: nur die Fehlerzeile, sonst nichts (AK 4)
+            assertTrue(anlage.uiState.value.nummerFehlt)
+            assertNull(anlage.uiState.value.gestarteterVorgangId)
+            verifyBlocking(repository, never()) { erstelleVorgang(any()) }
+            verifyBlocking(repository, never()) { schrittAnlegen(any()) }
+        }
+
+        @Test
+        fun `legt bei einem zweiten Tap keinen zweiten Vorgang an`() = runTest(dispatcher) {
+            // Given: der Vorgang ist bereits gestartet
+            val anlage = anlegen()
+            anlage.onAuftragsnummerGeaendert("2026-0815")
+            anlage.onStartenGetippt()
+            testScheduler.runCurrent()
+
+            // When: der Mechaniker tippt mit Handschuhen ein zweites Mal
+            anlage.onStartenGetippt()
+            testScheduler.runCurrent()
+
+            // Then: es bleibt bei einem Vorgang (AK 3)
+            verifyBlocking(repository) { erstelleVorgang(any()) }
+            verify(repository, never()).aktualisiereVorgang(any())
+        }
+    }
+
+    private fun anlegen() = NeuerVorgangViewModel(repository, fotoManager)
+
+    private companion object {
+        const val VORGANG_ID = 7L
+        const val ZIEL_PFAD = "/photos/fahrzeug.jpg"
+    }
+}

--- a/docs/specs/F-002-vorgang-anlegen/anlegen.md
+++ b/docs/specs/F-002-vorgang-anlegen/anlegen.md
@@ -4,7 +4,7 @@
 
 Der Mechaniker steht vor dem Fahrzeug und will einen neuen Reparaturvorgang beginnen. Der Flow ist bewusst Foto-first: Zuerst wird das Fahrzeug fotografiert (visuelles Wiederfinden in der Uebersicht), dann werden die Auftragsdaten erfasst. Nur die Auftragsnummer ist Pflicht — alles andere soll den Mechaniker nicht aufhalten.
 
-Der Flow hat genau einen Weg vorwaerts: **„LOS GEHT'S"** legt den Vorgang **und** dessen Schritt 1 an und fuehrt unmittelbar in die Demontage (F-003). Er hat genau einen Weg zurueck: den System-Back-Button bzw. den Zurueck-Chip, der nichts anlegt. Ein versehentlich angelegter Vorgang wird in der Uebersicht (F-001) per Swipe geloescht.
+Der Flow hat genau einen Weg vorwaerts: **„LOS GEHT'S"** legt den Vorgang an und fuehrt unmittelbar in die Demontage (F-003); den ersten Schritt legt dort F-003 an. Er hat genau einen Weg zurueck: den System-Back-Button bzw. den Zurueck-Chip, der nichts anlegt. Ein versehentlich angelegter Vorgang wird in der Uebersicht (F-001) per Swipe geloescht.
 
 Farben, Schriften, Glasflaechen und Maße stehen in [../design-system.md](../design-system.md); diese Spec nennt nur Wortlaute und Verhalten.
 
@@ -60,13 +60,14 @@ Farben, Schriften, Glasflaechen und Maße stehen in [../design-system.md](../des
   **And** das Nummernfeld zeigt als Platzhalter (wörtlich) **„2026-0815"**, das Beschreibungsfeld (wörtlich) **„Bremsen vorne wechseln"**
   **And** „WAS IST ZU TUN?" bildet `Reparaturvorgang.beschreibung` ab und trägt keine Pflichtmarkierung
 
-##### AK 2: „LOS GEHT'S" legt Vorgang und Schritt 1 an
+##### AK 2: „LOS GEHT'S" legt den Vorgang an und übergibt an die Demontage
 
 - **Given** das Formular zeigt ein Fahrzeugfoto und eine ausgefüllte Auftragsnummer
   **When** der Mechaniker „LOS GEHT'S" antippt
   **Then** wird der Reparaturvorgang mit Fahrzeugfoto, Auftragsnummer und Beschreibung im Status OFFEN gespeichert
-  **And** in derselben Aktion wird sein erster `Schritt` mit `schrittNummer = 1` angelegt
+  **And** es wird **kein** `Schritt` angelegt — die Schritt-Anlage gehört vollständig F-003
   **And** die Schritt-Ansicht der Demontage (F-003) wird für diesen Vorgang geöffnet
+  **And** F-003 findet dort keinen offenen Schritt vor, legt daher Schritt 1 an und startet die System-Kamera automatisch (siehe [../F-003-demontage/workflow.md](../F-003-demontage/workflow.md), Entry-Transition)
 
 ##### AK 3: Der Anlage-Screen bleibt nicht im Rückwärtsstapel
 
@@ -152,14 +153,16 @@ Farben, Schriften, Glasflaechen und Maße stehen in [../design-system.md](../des
 - Room Entity: `Reparaturvorgang(id, fahrzeugFotoPfad, auftragsnummer, beschreibung, status, erstelltAm, aktualisiertAm)`
 - `beschreibung`: Nullable. Ein leer gelassenes Feld „WAS IST ZU TUN?" wird als `null` gespeichert, nicht als leerer Text
 - `aktualisiertAm`: Zeitstempel der letzten Änderung. F-001 sortiert danach und leitet daraus das Abschlussdatum archivierter Vorgänge ab. Ein eigener Archivierungs-Zeitstempel existiert **nicht**
-- „LOS GEHT'S" schreibt in einer Aktion `Reparaturvorgang` **und** `Schritt` (`schrittNummer = 1`, `gestartetAm`) und navigiert dann zur Schritt-Ansicht (F-003) mit `vorgangId`. Der Anlage-Screen wird dabei aus dem Rückwärtsstapel entfernt
+- „LOS GEHT'S" schreibt den `Reparaturvorgang` und navigiert dann zur Schritt-Ansicht (F-003) mit `vorgangId`. Der Anlage-Screen wird dabei aus dem Rückwärtsstapel entfernt. Den `Schritt` legt F-003 an — F-002 kennt die Schrittnummern-Logik nicht
 - Doppel-Tap-Schutz: „LOS GEHT'S" ist debounced (300ms, [../governance.md](../governance.md), Abschnitt "Debounce") und wirkt nach dem ersten erfolgreichen Anlegen nicht erneut
 - Abbruch vor dem Anlegen: die angelegte Zieldatei unter `photos/` sofort löschen. Verbleibende Dateien ohne DB-Referenz — geprüft gegen `SchrittFoto.pfad` und `Reparaturvorgang.fahrzeugFotoPfad` — räumt die Cleanup-Regel beim App-Start auf
 - Spätere Erweiterung: OCR-Scanner für die Auftragsnummer vom Auftragszettel
 
-### [OFFEN] Kamera-Autostart für Schritt 1
+### Kamera-Autostart für Schritt 1 (entschieden am 2026-08-01)
 
-Nach „LOS GEHT'S" landet der Mechaniker in der Schritt-Ansicht von Schritt 1 mit leerem Karussell und löst die Kamera dort selbst über „NOCH'N FOTO" aus. Der Design-Prototyp öffnet an dieser Stelle die Kamera für Schritt 1 automatisch (Transition „LOS GEHT'S" → Kamera). Welche der beiden Varianten gilt, ist zu entscheiden; die Akzeptanzkriterien der Schritt-Ansicht führen denselben Punkt (siehe [../F-003-demontage/views/schritt-ansicht.md](../F-003-demontage/views/schritt-ansicht.md), US-003.1 AK 1).
+**Die Kamera startet automatisch.** Nach „LOS GEHT'S" landet der Mechaniker nicht in einer leeren Maske, sondern direkt in der System-Kamera für Schritt 1 — so, wie es der Design-Prototyp zeichnet. Der frühere Zustand (leeres Karussell, Kamera erst über „NOCH'N FOTO") war eine Abweichung vom Soll und ist behoben.
+
+Zuständig dafür ist **F-003, nicht F-002**: der Autostart hängt nicht am Anlage-Flow, sondern an der Entry-Bedingung „kein offener Schritt vorhanden". Dieselbe Regel greift beim Wiedereinstieg über F-001 nach dem Feierabend. F-002 legt deshalb keinen Schritt mehr an; die Regel steht vollständig in [../F-003-demontage/workflow.md](../F-003-demontage/workflow.md).
 
 ## UI-Skizze
 
@@ -213,3 +216,4 @@ Nach „LOS GEHT'S" landet der Mechaniker in der Schritt-Ansicht von Schritt 1 m
 | Datum | Änderung |
 |---|---|
 | 2026-07-27 | Auf das Design-System nachgezogen: System-Kamera ist Ist-Zustand (CameraX-Warnungen entfallen), „LOS GEHT'S" legt Vorgang und Schritt 1 an und verlässt den Rückwärtsstapel (AK 2/AK 3), Wortlaute „NEUER AUFTRAG", „↺ NEU KNIPSEN", „AUFTRAGSNUMMER", „WAS IST ZU TUN?", „LOS GEHT'S", „Ohne Nummer geht's nicht." (erst nach einem Versuch) festgeschrieben, Platzhalter „2026-0815" / „Bremsen vorne wechseln". |
+| 2026-08-01 | `[OFFEN] Kamera-Autostart für Schritt 1` entschieden: die Kamera startet automatisch. Die Schritt-Anlage wandert dabei von F-002 zu F-003 (AK 2 umformuliert) — der Autostart hängt an der Entry-Bedingung „kein offener Schritt", nicht am Anlage-Flow, und gilt damit auch beim Wiedereinstieg über F-001. |

--- a/docs/specs/F-003-demontage/README.md
+++ b/docs/specs/F-003-demontage/README.md
@@ -306,10 +306,12 @@ Weitere Punkte:
 flowchart TD
     A["Flow starten"] -->|kein offener Schritt| N["Schritt N anlegen<br/>gestartetAm setzen"]
     A -->|offener Schritt vorhanden| SA
-    N -->|Kamera-Autostart| K["System-Kamera<br/>Intent"]
-    K -->|Foto bestaetigt| P["SchrittFoto anlegen<br/>Label Bauteil"]
+    N -->|Ansicht folgt, dann Kamera| K["System-Kamera<br/>Intent"]
+    K -->|Foto bestaetigt| P["SchrittFoto am Ziel-Schritt<br/>Label Bauteil"]
     P --> SA["Schritt-Ansicht<br/>offener Schritt N"]
-    K -->|Abgebrochen| SA
+    K -->|"Abgebrochen, Schritt hat Fotos"| SA
+    K -->|"Abgebrochen, Schritt fotolos"| RB["Rollback: Schritt loeschen<br/>Vorgaenger wieder oeffnen"]
+    RB --> SA
     K -->|Keine Kamera-App| SA
     SA -->|Label-Checkbox| L["SchrittFoto aktualisieren"]
     L --> SA
@@ -324,8 +326,8 @@ flowchart TD
     SM -->|Weiteres Foto| K
     SM -->|Zurueck zu Schritt N| SA
     SM -->|Thumbnail Schritt M2| SM
-    SA -->|Naechster Schritt| NX["Schritt N abschliessen<br/>Schritt N plus 1 anlegen"]
-    NX -->|Kamera-Autostart| K
+    SA -->|Naechstes Teil| NX["Schritt N abschliessen<br/>Schritt N plus 1 anlegen"]
+    NX -->|Ansicht folgt, dann Kamera| K
     SA -->|Beenden| E["Schritt N abschliessen<br/>ohne Fotos verwerfen"]
     E --> U["Uebersicht F-001"]
 ```

--- a/docs/specs/F-003-demontage/views/schritt-ansicht.md
+++ b/docs/specs/F-003-demontage/views/schritt-ansicht.md
@@ -38,24 +38,24 @@ Sie liegen unten rechts nebeneinander, von links nach rechts:
 |---|---|---|---|---|
 | klein | 60dp | (woertlich) **„↺"** | nur wenn der betrachtete Schritt mindestens ein Foto hat | „Wiederholen" am sichtbaren Foto |
 | mittel | 86dp | (woertlich) **„NOCH'N FOTO"** | immer | System-Kamera fuer ein weiteres Foto am **betrachteten** Schritt |
-| gross | 124dp | zweistellige Nummer plus (woertlich) **„NÄCHSTES"** bzw. (woertlich) **„ZURÜCK ZU"** | immer | siehe unten |
+| gross | 124dp | zweistellige Nummer plus (woertlich) **„NÄCHSTES TEIL"** bzw. (woertlich) **„ZURÜCK ZU"** | immer | siehe unten |
 
 Eine Aktionszeile oder -leiste gibt es nicht; die Rundbuttons sind die Bedienung.
 
-### Der grosse Rundbutton: „NÄCHSTES nn" oder „ZURÜCK ZU nn"
+### Der grosse Rundbutton: „NÄCHSTES TEIL nn" oder „ZURÜCK ZU nn"
 
 Der grosse Kreis behaelt Groesse und Position, wechselt aber Bedeutung, Beschriftung und Flaeche, je nachdem ob der betrachtete Schritt der offene ist:
 
 | Betrachteter Schritt | Kreis | Flaeche | `nn` |
 |---|---|---|---|
-| der offene Schritt N | „NÄCHSTES nn" | orange | die Nummer, die der naechste Schritt bekaeme (hoechste vergebene Nummer + 1) |
+| der offene Schritt N | „NÄCHSTES TEIL nn" | orange | die Nummer, die der naechste Schritt bekaeme (hoechste vergebene Nummer + 1) |
 | ein abgeschlossener Schritt M | „ZURÜCK ZU nn" | neutral | die Nummer des offenen Schritts N |
 
-**Begruendung (design-system.md, K-07):** Waere der Kreis immer „NÄCHSTES", haengt ein Fehltipp beim Nachschlagen eines alten Schritts eine Schrittnummer an, die moeglicherweise schon auf einem physischen Etikett klebt. Die Nummer ist die Korrelation zum Ablageort und wird nie umnummeriert.
+**Begruendung (design-system.md, K-07):** Waere der Kreis immer „NÄCHSTES TEIL", haengt ein Fehltipp beim Nachschlagen eines alten Schritts eine Schrittnummer an, die moeglicherweise schon auf einem physischen Etikett klebt. Die Nummer ist die Korrelation zum Ablageort und wird nie umnummeriert.
 
 Zusammen mit dem Kreis verschwindet am abgeschlossenen Schritt auch der Chip „FEIERABEND": beide Aktionen wirken auf den offenen Schritt, den der Mechaniker in diesem Moment nicht vor sich hat.
 
-> **[OFFEN]** Hat der Vorgang gar keinen offenen Schritt — alle Schritte sind abgeschlossen und der Mechaniker steigt ueber „Weiter demontieren" (F-001) wieder ein —, hat „ZURÜCK ZU nn" kein Ziel und „NÄCHSTES nn" erscheint nicht. Ob in diesem Fall beim Einstieg ein neuer Schritt angelegt wird (so beschreibt es [../workflow.md](../workflow.md), Abschnitt „Entry-Bedingungen") oder der Kreis „NÄCHSTES nn" zeigt, ist zu entscheiden.
+**Ein Zustand ohne offenen Schritt kommt nicht vor** (entschieden am 2026-08-01). Steigt der Mechaniker ueber „Weiter demontieren" (F-001) wieder ein und sind alle Schritte abgeschlossen, legt die Entry-Transition sofort einen neuen Schritt an und startet die System-Kamera ([../workflow.md](../workflow.md), Abschnitt „Reihenfolge beim Schritt-Start"). Der Kreis zeigt daher immer eine der beiden Auspraegungen dieser Tabelle; ein zielloses „ZURÜCK ZU 00" gibt es nicht. Die Invariante dahinter: solange die Demontage laeuft, hat der Vorgang genau einen offenen Schritt.
 
 ### Zwei Bedienelement-Gruppen
 
@@ -83,19 +83,27 @@ Verbindlich:
 
 #### Akzeptanzkriterien
 
-##### AK 1: Einstieg in den Flow
+##### AK 1: Einstieg mit offenem Schritt — ohne Kamera
 
 - **Given** ein Reparaturvorgang ist im Status OFFEN und hat einen Schritt mit `abgeschlossenAm = null`
-  **When** der Mechaniker den Demontage-Flow betritt (aus der Uebersicht oder direkt nach der Anlage in F-002)
+  **When** der Mechaniker den Demontage-Flow betritt
   **Then** zeigt die Schritt-Ansicht diesen offenen Schritt mit dessen Fotos
   **And** die System-Kamera wird beim Einstieg **nicht** automatisch gestartet — der Mechaniker loest sie ueber „NOCH'N FOTO" aus
   **And** hat der Schritt noch kein Foto, zeigt der Karussell-Bereich den Leer-Zustand aus F-006 (US-006.9)
 
-> **[OFFEN]** Derselbe Punkt wie in [../../F-002-vorgang-anlegen/anlegen.md](../../F-002-vorgang-anlegen/anlegen.md), Abschnitt „[OFFEN] Kamera-Autostart fuer Schritt 1": der Design-Prototyp startet die Kamera direkt nach „LOS GEHT'S" fuer Schritt 1, der gebaute Flow nicht. Zu entscheiden.
+##### AK 1b: Einstieg ohne offenen Schritt — die Kamera beginnt
+
+*(Entschieden am 2026-08-01; loest den frueheren `[OFFEN]`-Punkt „Kamera-Autostart fuer Schritt 1" zusammen mit [../../F-002-vorgang-anlegen/anlegen.md](../../F-002-vorgang-anlegen/anlegen.md).)*
+
+- **Given** ein Reparaturvorgang ist im Status OFFEN und hat **keinen** Schritt mit `abgeschlossenAm = null` — entweder weil er frisch aus F-002 kommt und noch gar keinen Schritt hat, oder weil nach dem Feierabend alle Schritte abgeschlossen sind
+  **When** der Mechaniker den Demontage-Flow betritt
+  **Then** wird ein neuer Schritt angelegt (`schrittNummer` = hoechste vergebene Nummer + 1) und ist der betrachtete Schritt
+  **And** die System-Kamera startet **automatisch** fuer diesen Schritt — es erscheint keine leere Maske, die erst „NOCH'N FOTO" verlangt
+  **And** nach bestaetigter Aufnahme zeigt die Schritt-Ansicht den neuen Schritt mit diesem Foto
 
 ##### AK 2: Foto bestaetigt — sofort persistiert
 
-- **Given** die System-Kamera wurde fuer ein **neues** Foto geoeffnet („NOCH'N FOTO" oder Schritt-Start ueber „NÄCHSTES nn", **nicht** „↺")
+- **Given** die System-Kamera wurde fuer ein **neues** Foto geoeffnet („NOCH'N FOTO" oder Schritt-Start ueber „NÄCHSTES TEIL nn", **nicht** „↺")
   **When** der Mechaniker die Aufnahme in der System-Kamera bestaetigt
   **Then** ist das neue Foto als letztes im Karussell des Schritts sichtbar — es bekommt `reihenfolge` = Anzahl der bisherigen Fotos dieses Schritts
   **And** das Label „BAUTEIL" ist gesetzt, „ÜBERSICHT" und „ABLAGEORT" nicht
@@ -106,11 +114,21 @@ Verbindlich:
 
 ##### AK 3: System-Kamera wird abgebrochen
 
-- **Given** die System-Kamera wurde fuer ein **neues** Foto geoeffnet (**nicht** „↺")
+- **Given** die System-Kamera wurde ueber „NOCH'N FOTO" fuer einen Schritt geoeffnet, der bereits mindestens ein Foto hat (**nicht** „↺")
   **When** der Mechaniker die Aufnahme abbricht (Back-Taste oder Abbrechen)
   **Then** wird kein Foto zum Schritt hinzugefuegt und keine Datei behalten
-  **And** die Schritt-Ansicht wird angezeigt
-  **And** hat der Schritt noch kein Foto, zeigt der Karussell-Bereich den Leer-Zustand aus F-006 (US-006.9)
+  **And** die Schritt-Ansicht zeigt unveraendert denselben Schritt mit seinen bisherigen Fotos
+
+##### AK 3b: Abbruch am frisch eroeffneten Schritt rollt zurueck
+
+- **Given** die System-Kamera wurde vom **Schritt-Start** geoeffnet („NÄCHSTES TEIL nn" oder der Einstieg aus AK 1b) und der eben angelegte Schritt hat kein Foto
+  **When** der Mechaniker die Aufnahme abbricht (Back-Taste oder Abbrechen)
+  **Then** wird der eben angelegte Schritt geloescht und seine Nummer wieder frei
+  **And** der Vorgaenger ist wieder der offene und der betrachtete Schritt, mit seinen Fotos
+  **And** der grosse Kreis ist wieder orange und traegt „NÄCHSTES TEIL" mit derselben Nummer wie vor dem Tap
+  **And** existiert kein Vorgaenger (Schritt 1 eines neuen Vorgangs), bleibt dieser Schritt offen und leer stehen; der Karussell-Bereich zeigt den Leer-Zustand aus F-006 (US-006.9)
+
+  *(Wirkung und Begruendung stehen vollstaendig in [../workflow.md](../workflow.md), Abschnitt „Rollback beim Abbruch am frischen Schritt".)*
 
 ##### AK 4: Keine Kamera-App verfuegbar
 
@@ -188,19 +206,21 @@ Verbindlich:
 
 - **Given** der Demontage-Flow ist aktiv und die Ansicht zeigt den offenen Schritt N mit mindestens einem Foto
   **When** die Schritt-Ansicht angezeigt wird
-  **Then** sind unten rechts genau drei Rundbuttons sichtbar: „↺", „NOCH'N FOTO" und der orange Kreis mit der Nummer N+1 und dem Wort „NÄCHSTES"
+  **Then** sind unten rechts genau drei Rundbuttons sichtbar: „↺", „NOCH'N FOTO" und der orange Kreis mit der Nummer N+1 und den Worten „NÄCHSTES TEIL"
   **And** oben rechts ist der Chip „FEIERABEND" sichtbar
   **And** die drei Label-Chips sind sichtbar
   **And** die Thumbnail-Leiste zeigt alle Schritte des Vorgangs
 
-##### AK 2: „NÄCHSTES nn"
+##### AK 2: „NÄCHSTES TEIL nn"
 
 - **Given** die Schritt-Ansicht zeigt den offenen Schritt N
-  **When** der Mechaniker den orangen Kreis „NÄCHSTES nn" antippt
+  **When** der Mechaniker den orangen Kreis „NÄCHSTES TEIL nn" antippt
   **Then** wird `abgeschlossenAm` am Schritt N gesetzt
   **And** ein neuer `Schritt` mit `schrittNummer` = N+1 und `gestartetAm` wird angelegt
+  **And** der betrachtete Schritt wechselt auf N+1, **bevor** die Kamera startet — nicht erst bei ihrer Rueckkehr ([../workflow.md](../workflow.md), Abschnitt „Reihenfolge beim Schritt-Start")
   **And** die System-Kamera startet automatisch fuer den neuen Schritt
-  **And** nach der Rueckkehr zeigt die Ansicht den neuen Schritt, und der Kreis traegt jetzt die Nummer N+2
+  **And** nach bestaetigter Aufnahme haengt das Foto an Schritt N+1, die Ansicht zeigt Schritt N+1, und der Kreis traegt „NÄCHSTES TEIL" mit der Nummer N+2
+  **And** der Kreis wechselt zu keinem Zeitpunkt auf „ZURÜCK ZU" — der Mechaniker ist vorwaerts gegangen, nicht in einen alten Schritt gesprungen
 
 ##### AK 3: Debounce
 
@@ -223,7 +243,7 @@ Verbindlich:
 - **Given** die Schritt-Ansicht zeigt den abgeschlossenen Schritt 2, waehrend Schritt 5 offen ist
   **When** der Mechaniker den Kreis „ZURÜCK ZU 05" antippt
   **Then** zeigt die Schritt-Ansicht wieder Schritt 5 mit dessen Fotos
-  **And** der Kreis ist wieder orange und traegt „NÄCHSTES 06", der Chip „FEIERABEND" ist wieder sichtbar
+  **And** der Kreis ist wieder orange und traegt „NÄCHSTES TEIL 06", der Chip „FEIERABEND" ist wieder sichtbar
   **And** es wurde kein Schritt abgeschlossen, angelegt oder geloescht
 
 ##### AK 6: Foto-Aktionen bleiben am betrachteten Schritt
@@ -321,10 +341,10 @@ Die Messung selbst gehoert dem Service F-005 ([../../F-005-zeiterfassung/service
   **And** der angezeigte Wert bleibt stehen und geht nicht verloren
   **And** ein erneutes Starten setzt die Zaehlung fort, statt bei `00:00` zu beginnen
 
-##### AK 4: „NÄCHSTES nn" zieht die Messung mit
+##### AK 4: „NÄCHSTES TEIL nn" zieht die Messung mit
 
 - **Given** die Zeitmessung fuer den offenen Schritt N laeuft
-  **When** der Mechaniker „NÄCHSTES nn" antippt
+  **When** der Mechaniker „NÄCHSTES TEIL nn" antippt
   **Then** wird die Messung an Schritt N gestoppt
   **And** fuer den neu angelegten Schritt N+1 laeuft die Messung automatisch
 
@@ -358,17 +378,18 @@ Die Messung selbst gehoert dem Service F-005 ([../../F-005-zeiterfassung/service
 
 | Aktion | DB-Operation |
 |--------|-------------|
-| Schritt beginnt („NÄCHSTES nn", oder Schritt 1 durch F-002) | Neuen `Schritt` anlegen: `reparaturvorgangId`, `schrittNummer`, `gestartetAm` |
-| Foto in der System-Kamera bestaetigt — Kamera kam aus „NOCH'N FOTO" oder aus „NÄCHSTES nn" | Neues `SchrittFoto`: `schrittId` des **betrachteten** Schritts, `pfad`, `reihenfolge` = Anzahl bisheriger Fotos dieses Schritts (0-basiert, also hinten angehaengt), `istBauteil = true`, `istUebersicht = false`, `istAblageort = false`, `aufgenommenAm` |
+| Schritt beginnt („NÄCHSTES TEIL nn", oder der Einstieg ohne offenen Schritt) | Neuen `Schritt` anlegen: `reparaturvorgangId`, `schrittNummer`, `gestartetAm`. Bei „NÄCHSTES TEIL nn" zusaetzlich `abgeschlossenAm` am Vorgaenger setzen |
+| Foto in der System-Kamera bestaetigt — Kamera kam aus „NOCH'N FOTO" oder aus „NÄCHSTES TEIL nn" | Neues `SchrittFoto`: `schrittId` des **beim Kamera-Start festgehaltenen Ziel-Schritts**, `pfad`, `reihenfolge` = Anzahl bisheriger Fotos dieses Schritts (0-basiert, also hinten angehaengt), `istBauteil = true`, `istUebersicht = false`, `istAblageort = false`, `aufgenommenAm` |
 | Foto in der System-Kamera bestaetigt — Kamera kam aus **„↺"** | **Erst jetzt** wird ersetzt, in einer Operation: neues `SchrittFoto` mit denselben Feldern, aber `reihenfolge` = `p` (die `reihenfolge` des ersetzten Fotos); die alte `SchrittFoto`-Zeile und die alte Datei werden geloescht. Die uebrigen Fotos behalten ihre `reihenfolge` |
-| System-Kamera abgebrochen / keine Kamera-App | Kein DB-Write. Vorbereitete Zieldatei loeschen. Kam die Kamera aus „↺", bleiben das alte Foto und seine Datei unveraendert erhalten |
+| System-Kamera abgebrochen / keine Kamera-App — Schritt hat Fotos, oder die Kamera kam aus „NOCH'N FOTO" bzw. „↺" | Kein DB-Write. Vorbereitete Zieldatei loeschen. Kam die Kamera aus „↺", bleiben das alte Foto und seine Datei unveraendert erhalten |
+| System-Kamera abgebrochen / keine Kamera-App — Kamera kam vom **Schritt-Start** und der Schritt ist fotolos | **Rollback:** den eben angelegten `Schritt` loeschen und am Vorgaenger `abgeschlossenAm` auf `null` zuruecksetzen. Zieldatei loeschen. Ohne Vorgaenger bleibt der Schritt bestehen |
 | Label-Chip umgeschaltet | Update auf dem `SchrittFoto` des sichtbaren Fotos (`istBauteil` / `istUebersicht` / `istAblageort`) |
 | „↺" angetippt | **Kein DB-Write beim Tap.** Gemerkt werden nur die `SchrittFoto`-Id und `p` = deren `reihenfolge`; ersetzt wird erst nach erfolgreicher Neuaufnahme |
 | „NOCH'N FOTO" angetippt | Kein DB-Write beim Tap |
 | Karussell wischen / Foto in Vollbild oeffnen | Kein DB-Write |
 | Thumbnail eines anderen Schritts antippen (F-006) | Kein DB-Write. Fotos des gewaehlten Schritts werden geladen |
 | „ZURÜCK ZU nn" | Kein DB-Write. Fotos des offenen Schritts werden geladen |
-| „NÄCHSTES nn" | `abgeschlossenAm` am offenen Schritt setzen **und** neuen `Schritt` (N+1) anlegen |
+| „NÄCHSTES TEIL nn" | `abgeschlossenAm` am offenen Schritt setzen **und** neuen `Schritt` (N+1) anlegen |
 | „JA, FEIERABEND" | Wirkung und DB-Operation stehen bei US-003.5 in [../workflow.md](../workflow.md) |
 | Timer-Chip angetippt | Kein Schreibvorgang an `Schritt` oder `SchrittFoto`. Der Service F-005 legt in seiner eigenen Tabelle eine `ZeitMessung` an bzw. schliesst die offene |
 
@@ -389,11 +410,11 @@ Die Messung selbst gehoert dem Service F-005 ([../../F-005-zeiterfassung/service
 
 - **System-Kamera:** `ActivityResultContracts.TakePicture()` + `FileProvider` — kein CameraX, keine `CAMERA`-Permission
 - **Zieldatei:** Wird vor dem Intent in `photos/` angelegt und als FileProvider-URI uebergeben. Kein `photos/temp/`, kein Verschiebe-Schritt nach der Aufnahme
-- **Auto-Start:** Der Kamera-Intent wird beim Anlegen eines Schritts ueber „NÄCHSTES nn" automatisch ausgeloest. Beim Betreten des Flows wird er **nicht** ausgeloest (US-003.1 AK 1)
+- **Auto-Start:** Der Kamera-Intent wird beim Anlegen eines Schritts ueber „NÄCHSTES TEIL nn" automatisch ausgeloest. Beim Betreten des Flows wird er **nicht** ausgeloest (US-003.1 AK 1)
 - **EXIF:** Metadaten werden nach der Rueckkehr aus der System-Kamera entfernt, bevor die `SchrittFoto`-Zeile geschrieben wird
 - **F-006-Einbettung:** Foto-Karussell, Thumbnail-Leiste, Label-Chips, Foto-Indikator und Vollbild-Ansicht kommen als Komponenten aus F-006 (bearbeitbarer Modus). Die Bedienelemente „Zurueck"/„Weiter" (F-006 US-006.10) werden **nicht** angedockt. Kopfzeile, Timer-Chip und die Rundbuttons haengt F-003 in die dafuer vorgesehenen Slots
 - **Anzeige-Reihenfolge:** F-003 uebergibt die Schritte des Vorgangs **aufsteigend nach `schrittNummer`**
-- **Betrachteter vs. offener Schritt:** Das ViewModel haelt beides getrennt. Der **betrachtete** Schritt steuert Anzeige, Foto-Aktionen, „NOCH'N FOTO" und den Timer-Chip; der **offene** Schritt (`abgeschlossenAm = null`) ist Ziel von „NÄCHSTES nn" und „FEIERABEND". Sind beide identisch, ist der grosse Kreis orange und „FEIERABEND" sichtbar, sonst zeigt der Kreis „ZURÜCK ZU nn" und „FEIERABEND" entfaellt
+- **Betrachteter vs. offener Schritt:** Das ViewModel haelt beides getrennt. Der **betrachtete** Schritt steuert Anzeige, Foto-Aktionen, „NOCH'N FOTO" und den Timer-Chip; der **offene** Schritt (`abgeschlossenAm = null`) ist Ziel von „NÄCHSTES TEIL nn" und „FEIERABEND". Sind beide identisch, ist der grosse Kreis orange und „FEIERABEND" sichtbar, sonst zeigt der Kreis „ZURÜCK ZU nn" und „FEIERABEND" entfaellt
 - **Sichtbares Foto:** Die Karussell-Position ist der State, an dem Label-Chips und „↺" haengen. Sie wird im ViewModel gehalten und mit dem von F-006 gemeldeten sichtbaren Foto synchron gehalten
 - **Zeiterfassung:** ueber das Interface aus F-005 mit `referenzId = Schritt.id` und dem Referenztyp des Demontage-Schritts. Die Timer-Daten liegen in der eigenen Tabelle des Service-Features, nie am `Schritt` (Governance: keine Dual-Purpose-Felder)
 - **State Hoisting:** Der Screen erhaelt State (Schrittnummer, Fotoliste mit Labels, Karussell-Position, Schrittliste fuer die Thumbnail-Leiste, Index des betrachteten Schritts, Nummer des offenen Schritts, Timer-Stand) und Callbacks vom ViewModel
@@ -402,4 +423,4 @@ Die Messung selbst gehoert dem Service F-005 ([../../F-005-zeiterfassung/service
 
 | Datum | Aenderung |
 |---|---|
-| 2026-07-27 | Auf das Design-System nachgezogen: drei Rundbuttons („↺" 60dp, „NOCH'N FOTO" 86dp, grosser Kreis 124dp) statt einer Aktionszeile; der grosse Kreis zeigt „NÄCHSTES nn" nur am offenen Schritt und sonst neutral „ZURÜCK ZU nn" (K-07), „FEIERABEND" verschwindet dabei; „Beenden" heisst in der Oberflaeche „FEIERABEND" und fragt ueber ein Bottom-Sheet nach (K-08); Schrittnummer als 118sp-Ziffer oben links; „Zurueck"/„Weiter" aus F-006 werden nicht angedockt (K-05); neue US-003.7 fuer den Timer-Chip (K-03, K-04); Kamera-Autostart nur noch bei „NÄCHSTES nn". |
+| 2026-07-27 | Auf das Design-System nachgezogen: drei Rundbuttons („↺" 60dp, „NOCH'N FOTO" 86dp, grosser Kreis 124dp) statt einer Aktionszeile; der grosse Kreis zeigt „NÄCHSTES TEIL nn" nur am offenen Schritt und sonst neutral „ZURÜCK ZU nn" (K-07), „FEIERABEND" verschwindet dabei; „Beenden" heisst in der Oberflaeche „FEIERABEND" und fragt ueber ein Bottom-Sheet nach (K-08); Schrittnummer als 118sp-Ziffer oben links; „Zurueck"/„Weiter" aus F-006 werden nicht angedockt (K-05); neue US-003.7 fuer den Timer-Chip (K-03, K-04); Kamera-Autostart nur noch bei „NÄCHSTES TEIL nn". |

--- a/docs/specs/F-003-demontage/workflow.md
+++ b/docs/specs/F-003-demontage/workflow.md
@@ -56,12 +56,15 @@ Immer wenn ein Schritt **beginnt** -- beim Entry ohne offenen Schritt und bei "N
 
 1. Den Vorgaenger abschliessen, falls es einen offenen gibt (`abgeschlossenAm` = jetzt).
 2. Den neuen `Schritt` anlegen und seine Zeitmessung starten (F-005).
-3. **Den betrachteten Schritt auf den neuen Schritt setzen.**
-4. Erst jetzt die System-Kamera starten, mit der Id des neuen Schritts als Ziel.
+3. Erst jetzt die System-Kamera starten, mit der Id des neuen Schritts als Ziel.
 
-Punkt 3 vor Punkt 4 ist keine Kosmetik. Startet die Kamera parallel zur Schritt-Anlage, kehrt sie in eine Ansicht zurueck, die noch auf dem alten -- inzwischen abgeschlossenen -- Schritt steht: das Foto landet am falschen Schritt, und die Aktionszeile faellt auf ihre zweite Auspraegung zurueck ("Zurueck zu Schritt N"), obwohl der Mechaniker gerade vorwaerts gegangen ist.
+Punkt 2 vor Punkt 3 ist keine Kosmetik. Startet die Kamera parallel zur Schritt-Anlage, gibt es bei ihrer Rueckkehr keinen verlaesslichen Schritt, an den das Foto gehoert -- es landete am zuletzt betrachteten, und der ist in diesem Moment der eben abgeschlossene.
 
-**Das Ziel der Aufnahme ist die Schritt-Id, die beim Kamera-Start feststand** -- nicht der Schritt, der bei der Rueckkehr gerade betrachtet wird. Beides faellt im Normalfall zusammen; die Id festzuhalten macht die Zuordnung unabhaengig davon, was waehrend der Aufnahme sonst noch passiert.
+**Das Ziel der Aufnahme ist die Schritt-Id, die beim Kamera-Start feststand** -- nicht der Schritt, der bei der Rueckkehr gerade betrachtet wird. Die Id festzuhalten macht die Zuordnung unabhaengig davon, was waehrend der Aufnahme sonst noch passiert.
+
+**Der betrachtete Schritt zieht getrennt davon nach.** Er wechselt nicht im selben Atemzug auf den neuen Schritt, sondern sobald dieser ueber die Datenmeldung ankommt. Das ist bewusst ein eigener Weg und keine Reihenfolge-Bedingung: die Zuordnung des Fotos haengt an der festgehaltenen Id, nicht daran, was die Ansicht gerade zeigt.
+
+**Navigiert der Mechaniker in der Zwischenzeit selbst** -- er tippt in dem Moment ein Thumbnail an --, wird der vorgemerkte Wechsel **verworfen**. Wer selbst navigiert, hat das letzte Wort; ihn eine Sekunde spaeter von einer Datenmeldung wegziehen zu lassen, waere derselbe Fehler wie ein Sprung beim Eintreffen eines Fotos (US-006.4).
 
 ## Rollback beim Abbruch am frischen Schritt
 

--- a/docs/specs/F-003-demontage/workflow.md
+++ b/docs/specs/F-003-demontage/workflow.md
@@ -15,12 +15,13 @@
 
 | Von | Event | Nach | Bedingung | DB-Aktion |
 |-----|-------|------|-----------|-----------|
-| -- (Entry) | Flow starten | `KAMERA` | Reparaturvorgang ist OFFEN, kein offener Schritt vorhanden | `Schritt` anlegen: `schrittNummer` = hoechste Nummer + 1, `gestartetAm` = jetzt. Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
+| -- (Entry) | Flow starten | `KAMERA` | Reparaturvorgang ist OFFEN, kein offener Schritt vorhanden -- gilt gleichermassen fuer den frisch angelegten Vorgang aus F-002 (der **keinen** Schritt mitbringt) und fuer den Wiedereinstieg ueber F-001, nachdem alle Schritte abgeschlossen sind | `Schritt` anlegen: `schrittNummer` = hoechste Nummer + 1, `gestartetAm` = jetzt. Der betrachtete Schritt ist dieser neue Schritt. Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
 | -- (Entry) | Flow fortsetzen | `SCHRITT_ANSICHT` | Es existiert ein Schritt mit `abgeschlossenAm = null` | Keine (bestehender Schritt wird geladen) |
 | `KAMERA` | Foto in der System-Kamera bestaetigt | `SCHRITT_ANSICHT` | Die Kamera kam aus dem Schritt-Start oder aus "Weiteres Foto" | `SchrittFoto` anlegen: `schrittId` des Schritts, der die Kamera gestartet hat (nach einem Sprung der betrachtete, sonst der offene Schritt), `pfad`, `reihenfolge` = Anzahl bisheriger Fotos des Schritts (0-basiert, also hinten angehaengt), `istBauteil = true`, `istUebersicht = false`, `istAblageort = false`, `aufgenommenAm` = jetzt. Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
 | `KAMERA` | Foto in der System-Kamera bestaetigt | `SCHRITT_ANSICHT` | Die Kamera kam aus **"Wiederholen"** | **Jetzt erst** wird ersetzt, in einer Operation: neues `SchrittFoto` mit denselben Feldern wie oben, aber `reihenfolge` = `p` (die `reihenfolge` des ersetzten Fotos); die alte `SchrittFoto`-Zeile und die alte Datei werden geloescht. Die uebrigen Fotos behalten ihre `reihenfolge` -- es wird weder umnummeriert noch hinten angehaengt (Foto-Flow Logik Punkt 7). Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
-| `KAMERA` | Abgebrochen | `SCHRITT_ANSICHT` | -- | Keine. Angelegte Zieldatei wird geloescht, kein `SchrittFoto`. Kam die Kamera aus "Wiederholen", bleibt das alte Foto unveraendert erhalten |
-| `KAMERA` | Keine Kamera-App gefunden | `SCHRITT_ANSICHT` | -- | Keine. Hinweis-Dialog "Keine Kamera-App gefunden". Kam die Kamera aus "Wiederholen", bleibt das alte Foto unveraendert erhalten |
+| `KAMERA` | Abgebrochen | `SCHRITT_ANSICHT` | Die Kamera kam aus "Weiteres Foto" oder "Wiederholen", oder der Schritt hat bereits Fotos | Keine. Angelegte Zieldatei wird geloescht, kein `SchrittFoto`. Kam die Kamera aus "Wiederholen", bleibt das alte Foto unveraendert erhalten |
+| `KAMERA` | Abgebrochen | `SCHRITT_ANSICHT` (Vorgaenger N) | Die Kamera kam aus dem **Schritt-Start** (Entry oder "Naechster Schritt") und der eben angelegte Schritt N+1 hat **kein Foto** | **Rollback**, siehe Abschnitt "Rollback beim Abbruch am frischen Schritt": Schritt N+1 loeschen, Schritt N wieder oeffnen (`abgeschlossenAm = null`). Zieldatei loeschen. Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
+| `KAMERA` | Keine Kamera-App gefunden | `SCHRITT_ANSICHT` | -- | Wie "Abgebrochen", einschliesslich Rollback. Zusaetzlich Hinweis-Dialog "Keine Kamera-App gefunden" |
 | `SCHRITT_ANSICHT` | Label-Checkbox umgeschaltet | `SCHRITT_ANSICHT` | Debounce 300ms, mind. 1 Foto sichtbar | `SchrittFoto` des sichtbaren Fotos updaten: `istBauteil` / `istUebersicht` / `istAblageort`. Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
 | `SCHRITT_ANSICHT` | Foto im Karussell gewischt | `SCHRITT_ANSICHT` | -- | Keine (Checkboxen zeigen die Flags des neu sichtbaren Fotos) |
 | `SCHRITT_ANSICHT` | "Wiederholen" am sichtbaren Foto | `KAMERA` | Debounce 300ms, mind. 1 Foto sichtbar | **Keine.** Das alte Foto und seine Datei bleiben unveraendert; gemerkt werden nur die `SchrittFoto`-Id und `p` = deren `reihenfolge` fuer die Ersetzung nach erfolgreicher Aufnahme (Governance-Regel "Kamera", siehe [../governance.md](../governance.md)) |
@@ -31,7 +32,7 @@
 | `SCHRITT_ANSICHT` (abgeschlossener Schritt M sichtbar) | "Zurueck zu Schritt N" | `SCHRITT_ANSICHT` (offener Schritt N) | Debounce 300ms | Keine -- reiner State-Wechsel im ViewModel |
 | `SCHRITT_ANSICHT` | Foto antippen (Vollbild, F-006) | `SCHRITT_ANSICHT` (Vollbild offen) | -- | Keine |
 | `SCHRITT_ANSICHT` (Vollbild offen, F-006) | Schliessen-Element oder Android-Zurueck-Taste | `SCHRITT_ANSICHT` (Vollbild geschlossen) | -- | Keine -- das Vollbild konsumiert die Back-Geste zuerst |
-| `SCHRITT_ANSICHT` (offener Schritt N sichtbar) | "Naechster Schritt" | `KAMERA` | Debounce 300ms; der Button ist nur sichtbar, wenn der betrachtete Schritt der offene ist | `abgeschlossenAm` = jetzt am Schritt N setzen **und** neuen `Schritt` N+1 anlegen (`schrittNummer` = N+1, `gestartetAm` = jetzt). Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
+| `SCHRITT_ANSICHT` (offener Schritt N sichtbar) | "Naechster Schritt" | `KAMERA` | Debounce 300ms; der Button ist nur sichtbar, wenn der betrachtete Schritt der offene ist | `abgeschlossenAm` = jetzt am Schritt N setzen **und** neuen `Schritt` N+1 anlegen (`schrittNummer` = N+1, `gestartetAm` = jetzt). **Der betrachtete Schritt wechselt dabei auf N+1**, bevor die Kamera startet -- siehe Abschnitt "Reihenfolge beim Schritt-Start". Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
 | `SCHRITT_ANSICHT` (offener Schritt N sichtbar, mind. 1 Foto) | "Beenden" | Uebersicht (F-001) | Debounce 300ms; der Button ist nur sichtbar, wenn der betrachtete Schritt der offene ist | `abgeschlossenAm` = jetzt am Schritt N setzen. Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
 | `SCHRITT_ANSICHT` (offener Schritt N sichtbar, **ohne Fotos**) | "Beenden" | Uebersicht (F-001) | Debounce 300ms | Schritt N **loeschen** statt abschliessen; die Nummer N wird beim naechsten Flow-Start erneut vergeben. Zusaetzlich `Reparaturvorgang.aktualisiertAm` = jetzt |
 | `SCHRITT_ANSICHT` | Android-Zurueck-Taste (kein Vollbild offen) | `SCHRITT_ANSICHT` | -- | Keine -- der Flow wird nicht verlassen (US-003.6) |
@@ -49,21 +50,59 @@ Damit bezieht sich jede sichtbare Aktion immer auf den Schritt, den der Mechanik
 
 **Getrennt davon: die Schritt-Navigation von F-006.** Die Aktionszeile ist **nicht** die einzige Bedienelement-Gruppe der Schritt-Ansicht. Thumbnail-Leiste sowie "Zurueck" und "Weiter" (F-006 US-006.2 und US-006.10) sind in allen drei F-006-Modi komponiert und daher auch in der Demontage **immer sichtbar**; an den Raendern der Anzeige-Reihenfolge sind sie lediglich deaktiviert. Sie wechseln nur den betrachteten Schritt und schreiben nichts in die DB. Die Abgrenzung zu den Schritt-Aktionen -- insbesondere "Weiter" gegenueber "Naechster Schritt" und "Zurueck" gegenueber "Zurueck zu Schritt N" -- ist in [views/schritt-ansicht.md](views/schritt-ansicht.md), Abschnitt "Zwei Bedienelement-Gruppen", verbindlich festgelegt.
 
+## Reihenfolge beim Schritt-Start
+
+Immer wenn ein Schritt **beginnt** -- beim Entry ohne offenen Schritt und bei "Naechster Schritt" -- gilt diese Reihenfolge verbindlich:
+
+1. Den Vorgaenger abschliessen, falls es einen offenen gibt (`abgeschlossenAm` = jetzt).
+2. Den neuen `Schritt` anlegen und seine Zeitmessung starten (F-005).
+3. **Den betrachteten Schritt auf den neuen Schritt setzen.**
+4. Erst jetzt die System-Kamera starten, mit der Id des neuen Schritts als Ziel.
+
+Punkt 3 vor Punkt 4 ist keine Kosmetik. Startet die Kamera parallel zur Schritt-Anlage, kehrt sie in eine Ansicht zurueck, die noch auf dem alten -- inzwischen abgeschlossenen -- Schritt steht: das Foto landet am falschen Schritt, und die Aktionszeile faellt auf ihre zweite Auspraegung zurueck ("Zurueck zu Schritt N"), obwohl der Mechaniker gerade vorwaerts gegangen ist.
+
+**Das Ziel der Aufnahme ist die Schritt-Id, die beim Kamera-Start feststand** -- nicht der Schritt, der bei der Rueckkehr gerade betrachtet wird. Beides faellt im Normalfall zusammen; die Id festzuhalten macht die Zuordnung unabhaengig davon, was waehrend der Aufnahme sonst noch passiert.
+
+## Rollback beim Abbruch am frischen Schritt
+
+Bricht der Mechaniker die Kamera ab, die **den Schritt eroeffnet hat**, und hat dieser Schritt kein einziges Foto, wird der Schritt-Start vollstaendig zurueckgenommen:
+
+- Der eben angelegte Schritt N+1 wird **geloescht**. Seine Nummer wird damit wieder frei und beim naechsten Schritt-Start erneut vergeben.
+- Der Vorgaenger N wird **wieder geoeffnet** (`abgeschlossenAm` zurueck auf `null`) und ist danach wieder der betrachtete Schritt.
+- Die Zeitmessung des verworfenen Schritts wird gestoppt; die des wieder geoeffneten Schritts laeuft weiter wie vor dem Tap.
+
+**Warum geloescht statt stehengelassen:** Weil die Kamera den Schritt eroeffnet, ist ihr Abbruch die einzige Moeglichkeit, "doch nicht" zu sagen. Ein leerer Schritt, der dabei zurueckbliebe, waere kein bewusst uebersprungener Schritt, sondern Muell -- er verbraucht eine Nummer, erscheint als leeres Thumbnail und schiebt die Nummerierung aller folgenden Teile um eins. Ohne Foto ist zu diesem Zeitpunkt auch nichts dokumentiert, das eine Nummer tragen koennte.
+
+**Warum der Vorgaenger wieder geoeffnet wird:** "Naechster Schritt" hat ihn abgeschlossen. Bliebe er abgeschlossen, haette der Vorgang nach dem Rollback **keinen** offenen Schritt mehr -- die Aktionszeile zeigte "Zurueck zu Schritt N" ins Leere und der Mechaniker kaeme nicht mehr weiter. Das Rollback stellt damit die Invariante wieder her, die den ganzen Flow traegt:
+
+> **Invariante:** Solange die Demontage laeuft, hat der Vorgang genau einen offenen Schritt.
+
+**Zwei Faelle, in denen nicht zurueckgerollt wird:**
+
+| Fall | Verhalten |
+|---|---|
+| Der Schritt hat bereits Fotos ("Weiteres Foto" abgebrochen, oder Abbruch nach einer geglueckten Aufnahme) | Es wird nichts geloescht und nichts wieder geoeffnet. Nur die leere Zieldatei verschwindet |
+| Es gibt keinen Vorgaenger (Schritt 1 eines neuen Vorgangs) | Schritt 1 bleibt leer und offen stehen -- es gibt kein Ziel, auf das zurueckgerollt werden koennte. Der Mechaniker holt die Aufnahme per "Weiteres Foto" nach oder verlaesst den Flow ueber "Beenden", das den fotolosen Schritt ohnehin verwirft |
+
 ## Navigations-Diagramm
 
 ```
 [Entry: Flow starten]
-  -> kein offener Schritt vorhanden -> Schritt N anlegen -> System-Kamera (automatisch)
-  -> offener Schritt vorhanden      -> Schritt-Ansicht (offener Schritt N)
+  -> kein offener Schritt vorhanden -> Schritt N anlegen, Ansicht auf N -> System-Kamera (automatisch)
+     (gilt fuer den neuen Vorgang aus F-002 und fuer den Wiedereinstieg nach Feierabend)
+  -> offener Schritt vorhanden      -> Schritt-Ansicht (offener Schritt N), keine Kamera
 
 System-Kamera (transient, kein App-Screen)
-  -> [Foto bestaetigt] -> Datei in photos/, SchrittFoto anlegen (Label Bauteil) -> Schritt-Ansicht
+  -> [Foto bestaetigt] -> Datei in photos/, SchrittFoto am Ziel-Schritt anlegen  -> Schritt-Ansicht
+                          (Label Bauteil; Ziel ist die beim Kamera-Start
+                           festgehaltene Schritt-Id)
                           (kam sie aus "Wiederholen": neues Foto auf Position p,
                            danach altes SchrittFoto + alte Datei loeschen)
   -> [Abgebrochen]     -> Zieldatei verwerfen, keine DB-Zeile                   -> Schritt-Ansicht
                           (kam sie aus "Wiederholen": altes Foto bleibt erhalten)
-  -> [Keine Kamera-App]-> Hinweis-Dialog                                        -> Schritt-Ansicht
-                          (kam sie aus "Wiederholen": altes Foto bleibt erhalten)
+                          (kam sie aus dem Schritt-Start und der Schritt ist
+                           fotolos: Rollback -> Schritt-Ansicht (Vorgaenger N))
+  -> [Keine Kamera-App]-> Hinweis-Dialog, sonst wie [Abgebrochen]               -> Schritt-Ansicht
 
 Schritt-Ansicht, offener Schritt N sichtbar
   -> [Label-Checkbox]        -> SchrittFoto-Update (sofort)          -> Schritt-Ansicht
@@ -74,7 +113,8 @@ Schritt-Ansicht, offener Schritt N sichtbar
   -> [Thumbnail Schritt M]   -> kein DB-Write                        -> Schritt-Ansicht (Schritt M)
   -> [F-006 "Zurueck"]       -> kein DB-Write                        -> Schritt-Ansicht (Schritt N-1)
   -> [F-006 "Weiter"]        -> deaktiviert (N ist der letzte Schritt der Anzeige-Reihenfolge)
-  -> [Naechster Schritt]     -> abgeschlossenAm(N), Schritt N+1      -> System-Kamera
+  -> [Naechster Schritt]     -> abgeschlossenAm(N), Schritt N+1,
+                                Ansicht folgt auf N+1                 -> System-Kamera (Schritt N+1)
   -> [Beenden]               -> abgeschlossenAm(N) bzw. Schritt N loeschen, falls ohne Fotos
                                                                       -> Uebersicht (F-001)
 
@@ -121,7 +161,7 @@ Die Schrittnummer wird **nicht** inkrementiert bei:
 - Sprung zu einem anderen Schritt ueber die Thumbnail-Leiste (F-006)
 - "Zurueck zu Schritt N" (Rueckkehr zum offenen Schritt nach einem Sprung)
 - "Beenden" (kein neuer Schritt). Wird dabei ein Schritt ohne Fotos verworfen, sinkt die naechste vergebene Nummer wieder auf dessen Nummer
-- Abbruch der System-Kamera
+- Abbruch der System-Kamera. Eroeffnete diese Kamera-Runde den Schritt und blieb er fotolos, wird der Schritt sogar zurueckgenommen -- die Nummer sinkt wieder auf seine (Abschnitt "Rollback beim Abbruch am frischen Schritt")
 
 ### Aus US-003.4 AK 3: Schrittnummer bei neuem Vorgang
 
@@ -136,6 +176,22 @@ Die Schrittnummer wird **nicht** inkrementiert bei:
   **When** der Mechaniker "Naechster Schritt" antippt
   **Then** wird ein Schritt mit `schrittNummer = 4` angelegt
   **And** nach Rueckkehr aus der System-Kamera zeigt die Schritt-Ansicht "Schritt 4"
+
+### Aus US-003.4 AK 7: Rollback nimmt die Nummer wieder zurueck
+
+- **Given** die Schritt-Ansicht zeigt den offenen Schritt 4 mit einem Foto
+  **When** der Mechaniker "Naechster Schritt" antippt und die System-Kamera dann abbricht
+  **Then** ist Schritt 5 wieder geloescht und Schritt 4 wieder offen
+  **And** die Schritt-Ansicht zeigt Schritt 4 mit seinem Foto
+  **And** die Aktionszeile bietet erneut "Naechster Schritt" an, beschriftet mit der Nummer 5
+
+### Aus US-003.4 AK 8: Ohne Vorgaenger wird nicht zurueckgerollt
+
+- **Given** ein neuer Reparaturvorgang ohne Schritte wird geoeffnet, Schritt 1 wird angelegt und die System-Kamera startet
+  **When** der Mechaniker die Kamera abbricht
+  **Then** bleibt Schritt 1 offen und ohne Fotos bestehen
+  **And** die Schritt-Ansicht zeigt Schritt 1 im Leer-Zustand des Karussells (F-006 US-006.9)
+  **And** es wird kein Schritt geloescht -- es gibt keinen Vorgaenger, auf den zurueckgerollt werden koennte
 
 ### Aus US-003.4 AK 5: Keine Inkrementierung bei weiterem Foto
 
@@ -184,7 +240,8 @@ Die beiden Timestamps markieren jetzt die **Klammer um den gesamten Schritt** in
 - **`aktualisiertAm`:** Jeder dieser Schreibvorgaenge zieht `Reparaturvorgang.aktualisiertAm` mit (projektweite Invariante, siehe [../governance.md](../governance.md))
 - **Abschluss:** `abgeschlossenAm` wird bei "Naechster Schritt" bzw. "Beenden" sofort geschrieben
 - **Leerer Schritt beim Beenden:** Hat der offene Schritt beim "Beenden" **kein einziges Foto** (Kamera abgebrochen, keine Kamera-App), wird er **geloescht** statt abgeschlossen. Sonst bliebe ein Schritt ohne Fotos in der DB, erschiene als leeres Thumbnail und wuerde eine Schrittnummer verbrauchen, die der Mechaniker bereits auf ein physisches Label geschrieben haben koennte. Die Nummer wird beim naechsten Flow-Start erneut vergeben
-- **Leerer Schritt bei "Naechster Schritt":** Wird **nicht** verworfen. Der Mechaniker geht hier bewusst weiter und kann den Schritt spaeter per Thumbnail-Sprung und "Weiteres Foto" nachtragen
+- **Leerer Schritt nach abgebrochenem Schritt-Start:** Wird **verworfen**, und der Vorgaenger wird wieder geoeffnet (Abschnitt "Rollback beim Abbruch am frischen Schritt"). Diese Regel ersetzt die frueher hier stehende Gegenregel ("wird nicht verworfen, der Mechaniker geht bewusst weiter"). Deren Begruendung setzte voraus, dass die Kamera **nicht** von selbst aufgeht -- dann war das Weitergehen eine eigene Entscheidung und der leere Schritt ein bewusst uebersprungener. Seit die Kamera den Schritt eroeffnet, ist ihr Abbruch das Gegenteil davon: ein "doch nicht"
+- **Nachtragen bleibt moeglich:** Ein Schritt, der ein Foto bekommen hat und spaeter ergaenzt werden soll, wird per Thumbnail-Sprung und "Weiteres Foto" nachgetragen. Verworfen wird ausschliesslich der Schritt, der **nie** eines hatte
 - **Unterbrechung:** Ein Schritt ohne `abgeschlossenAm` wird beim naechsten Start erkannt und fortgesetzt
 - **Orphaned Schritte:** Unterbrochene Schritte bleiben in der DB und werden beim Fortsetzen weiterbearbeitet (kein Loeschen). Verworfen wird ausschliesslich der fotolose Schritt beim "Beenden"
 - **Orphaned Dateien:** Dateien in `photos/`, auf die keine DB-Zeile verweist, fallen unter die projektweite Cleanup-Regel (siehe [../governance.md](../governance.md))
@@ -222,7 +279,7 @@ Die Akzeptanzkriterien dieser Story sind auf zwei Abschnitte verteilt: AK 1 und 
 
 Der Demontage-Flow wird gestartet:
 - Aus der Vorgangs-Uebersicht (F-001): Der Mechaniker tippt auf den Vorgang. Hat der Vorgang noch keinen Schritt, oeffnet sich der Demontage-Flow direkt; ab dem ersten Schritt erscheint der Auswahl-Dialog und der Mechaniker waehlt **"Weiter demontieren"**. Dialog und Beschriftung gehoeren F-001 (US-001.2) -- F-003 uebernimmt den dortigen Wortlaut unveraendert
-- Direkt nach Vorgang-Anlage (F-002): Automatischer Uebergang in den Demontage-Flow
+- Direkt nach Vorgang-Anlage (F-002): Automatischer Uebergang in den Demontage-Flow. F-002 bringt **keinen** Schritt mit -- der Vorgang ist leer, die Entry-Transition "Flow starten" greift, Schritt 1 entsteht hier und die System-Kamera startet automatisch
 
 ### Aus US-003.4 AK 6: Fortsetzung nach Unterbrechung
 
@@ -251,7 +308,7 @@ Der Demontage-Flow wird gestartet:
 |----------------------|----------------------|--------------------------|
 | `KAMERA` (System-Kamera im Vordergrund, kein Foto bestaetigt) | `Schritt` in DB (`abgeschlossenAm = null`), alle vorher aufgenommenen Fotos als `SchrittFoto` -- bei einer laufenden "Wiederholen"-Runde also auch das noch nicht ersetzte alte Foto; vorbereitete Zieldatei ohne DB-Zeile | Schritt-Ansicht fuer den **offenen** Schritt, mit unveraendertem Foto-Bestand. Die verwaiste Zieldatei faellt unter die Cleanup-Regel in [../governance.md](../governance.md) |
 | `SCHRITT_ANSICHT` | `Schritt` in DB (`abgeschlossenAm = null`), alle Fotos und Labels persistiert. Der **betrachtete** Schritt wird nicht persistiert | Schritt-Ansicht fuer den **offenen** Schritt (`abgeschlossenAm = null`), Karussell zeigt dessen Fotos in ihrer `reihenfolge` |
-| Direkt nach "Naechster Schritt" (Schritt N+1 noch ohne Foto) | Schritt N abgeschlossen, Schritt N+1 offen ohne Fotos | Schritt-Ansicht fuer Schritt N+1 (Karussell im Leer-Zustand, F-006 US-006.9) |
+| Direkt nach "Naechster Schritt" (Schritt N+1 noch ohne Foto) | Schritt N abgeschlossen, Schritt N+1 offen ohne Fotos | Schritt-Ansicht fuer Schritt N+1 (Karussell im Leer-Zustand, F-006 US-006.9). **Kein Rollback:** ein Prozess-Tod ist kein Abbruch -- die App hat nie ein Abbruch-Ergebnis der Kamera gesehen und darf einen Schritt nicht auf Verdacht loeschen. Der Mechaniker holt die Aufnahme per "Weiteres Foto" nach |
 | Direkt nach "Beenden" | Alle Schritte abgeschlossen; ein fotoloser letzter Schritt wurde dabei verworfen | Beim Fortsetzen wird ein neuer Schritt angelegt und die System-Kamera startet automatisch |
 
 **Der betrachtete Schritt ueberlebt eine Unterbrechung nicht.** Ein Sprung ueber die Thumbnail-Leiste oder ueber "Zurueck"/"Weiter" ist ein reiner ViewModel-State und wird bewusst **nicht** persistiert. Schliesst der Mechaniker die App, waehrend er Schritt 2 betrachtet und Schritt 5 offen ist, zeigt die Schritt-Ansicht nach dem Neustart **Schritt 5** -- also denselben Zustand wie die Entry-Transition "Flow fortsetzen". Begruendung: Der Mechaniker nimmt seine Arbeit dort wieder auf, wo sie unfertig ist; ein Wiedereinstieg mitten in einer abgeschlossenen Dokumentation wuerde ihn ueberraschen. Zu Schritt 2 kommt er mit einem Tap zurueck.

--- a/docs/specs/governance.md
+++ b/docs/specs/governance.md
@@ -101,7 +101,9 @@ Projektweit wird **ausschliesslich die System-Kamera** verwendet:
   3. Bricht der Nutzer die Kamera ab, bleibt das alte Foto vollstaendig und unveraendert erhalten (DB-Zeile, Datei, `reihenfolge`, Label).
 
   Grund: Quality Goal "Zuverlaessigkeit" — ein bereits aufgenommenes Foto darf durch einen Kamera-Abbruch nie verloren gehen. Ein "erst loeschen, dann Kamera starten" ist projektweit unzulaessig.
-- **Kamera-Abbruch:** Es wird keine DB-Zeile angelegt oder veraendert; geloescht wird ausschliesslich die fuer **diese** Aufnahme vorab erzeugte Zieldatei (siehe Abschnitt "Speicherort"). Beim "Wiederholen" bleiben die alte DB-Zeile und die alte Datei davon unberuehrt. Der Nutzer landet in der aufrufenden Ansicht.
+- **Kamera-Abbruch:** Es entsteht **kein Foto** — weder eine `SchrittFoto`-Zeile noch eine behaltene Datei. Geloescht wird ausschliesslich die fuer **diese** Aufnahme vorab erzeugte Zieldatei (siehe Abschnitt "Speicherort"). Vorhandene Fotos bleiben unberuehrt, beim "Wiederholen" also auch die alte Zeile und die alte Datei. Der Nutzer landet in der aufrufenden Ansicht.
+
+  **Reichweite dieser Regel:** Sie schuetzt **Fotos**. Sie sagt nichts darueber, was mit dem **Kontext** geschieht, den ein Feature eigens fuer diese Aufnahme angelegt hat. Oeffnet ein Feature die Kamera, um einen Kontext ueberhaupt erst zu eroeffnen — F-003 legt fuer "NÄCHSTES TEIL" einen neuen Schritt an —, darf es diese Anlage beim Abbruch wieder zuruecknehmen, solange dabei kein Foto verloren geht. Die Bedingungen dafuer gehoeren in die Feature-Spec, nicht hierher; fuer die Demontage stehen sie in [F-003-demontage/workflow.md](F-003-demontage/workflow.md), Abschnitt "Rollback beim Abbruch am frischen Schritt".
 
 Diese Regel gilt fuer alle Features ohne Ausnahme und ist deshalb hier verankert, nicht in einzelnen Feature-Specs.
 


### PR DESCRIPTION
## Warum

Zwei Beobachtungen beim Durchspielen am Emulator:

1. Nach „LOS GEHT'S" landete der Mechaniker in einer **leeren Maske** und musste die Kamera erst über „NOCH'N FOTO" selbst auslösen.
2. Nach „NÄCHSTES TEIL" sprang der große Kreis auf **„ZURÜCK ZU"**, obwohl der Mechaniker gerade vorwärts gegangen war. Ein Tap darauf führte zu einem leeren neuen Schritt.

Beides hat **dieselbe Wurzel**: die Kamera wurde von der Route gesteuert, parallel zur Schritt-Anlage.

- `NeuerVorgangViewModel` legte Schritt 1 selbst an → der Browser sah einen offenen Schritt, hielt das für eine Fortsetzung und startete keine Kamera. Der Kamera-Autostart steht seit jeher in `workflow.md`; das war also eine Abweichung vom Soll, kein neuer Wunsch.
- `BrowserRoute.onNaechstesTeil` feuerte den asynchronen DB-Schreib und `starteKamera()` gleichzeitig, und `aktiverIndex` folgte dem neuen Schritt nicht. Folge: die Ansicht blieb auf dem eben abgeschlossenen Schritt, **das Foto landete dort** (`onFotoAufgenommen` nahm `aktiverSchritt`), und `betrachtetOffenenSchritt` kippte auf `false`.

Kein Test deckte „die Ansicht folgt dem neuen Schritt" ab — deshalb ist es durchgerutscht.

## Was sich ändert

**Die Kamera-Hoheit wandert ins ViewModel**, nach dem Muster, das F-002 mit `KameraAuftrag` schon fährt. Der Auftrag trägt die **Ziel-Schritt-Id**, damit ein Foto strukturell nicht mehr am falschen Schritt landen kann; die Route hängt nur noch einen `LaunchedEffect` daran. Damit ist die Reihenfolge erzwungen: Schritt anlegen → Ansicht nachziehen → **dann erst** die Kamera.

**Neu entschieden ist das Rollback.** Bricht genau die Kamera ab, die den Schritt eröffnet hat, und blieb er fotolos, wird der Schritt gelöscht und sein Vorgänger wieder geöffnet. Die frühere Gegenregel („leerer Schritt wird nicht verworfen, der Mechaniker geht bewusst weiter") setzte voraus, dass die Kamera *nicht* von selbst aufgeht — seit sie den Schritt eröffnet, ist ihr Abbruch das Gegenteil eines bewussten Weitergehens.

Das Wiederöffnen des Vorgängers ist dabei der wichtigere Teil: ohne ihn hätte der Vorgang danach **keinen** offenen Schritt mehr — genau die Sackgasse aus #121. Daraus fällt die Invariante ab, die sie strukturell ausschließt:

> Solange die Demontage läuft, hat der Vorgang genau einen offenen Schritt.

Der Einstieg ohne offenen Schritt greift deshalb auch beim **Wiedereinstieg nach dem Feierabend** — dieselbe Codestelle. **Damit ist #121 miterledigt.**

## Verifikation

Am Emulator gegen die Datenbank geprüft, nicht nur per Screenshot:

| Schritt | `schritt`-Tabelle |
|---|---|
| Nach „LOS GEHT'S" | `1\|1\|OFFEN\|1 Foto` — F-002 legt keinen Schritt an, F-003 legt Schritt 1 an, Kamera lief |
| Während der „NÄCHSTES TEIL"-Kamera | `1\|1\|zu` + `2\|2\|OFFEN\|0` — Vorgänger zu, neuer Schritt offen |
| Nach Kamera-Abbruch | `1\|1\|OFFEN\|1 Foto` — Schritt 2 gelöscht, Schritt 1 wieder offen |

Der Kreis stand danach wieder orange auf „02 NÄCHSTES TEIL", der Timer des wieder geöffneten Schritts lief.

- **207 JVM-Tests** (vorher 189), alle grün
- **13 instrumentierte Tests** (`connectedDebugAndroidTest`), alle grün
- `ktlintCheck` / `detekt` **nicht gelaufen** — die gibt es in diesem Projekt weiterhin nicht

## Specs

Die Änderung geht über Spec → Test → Code. Angepasst:

- `F-003/workflow.md` — Abschnitte „Reihenfolge beim Schritt-Start" und „Rollback beim Abbruch am frischen Schritt" neu, Abbruch-Transition gesplittet, US-003.4 AK 7 und AK 8 ergänzt
- `F-003/views/schritt-ansicht.md` — AK 1b und AK 3b neu, Buttontext „NÄCHSTES TEIL"
- `F-002/anlegen.md` — legt keinen Schritt mehr an
- `governance.md` — Reichweite der Kamera-Abbruch-Regel geklärt: sie schützt **Fotos**, nicht den eigens angelegten Kontext

Drei `[OFFEN]`-Punkte sind damit aufgelöst, darunter zweimal „Kamera-Autostart für Schritt 1".

## Für den Reviewer

- **Zwei Alt-Tests wurden gedreht**, nicht gelöscht: sie beschrieben den stehenbleibenden Index bzw. den Zustand ohne offenen Schritt als richtig. Beides ist jetzt genau das, was der Fix verhindert.
- **`NeuerVorgangViewModelTest` ist neu** — F-002 hatte keine ViewModel-Tests. Für den geänderten AK habe ich RED explizit nachgewiesen (alte Zeile kurz wiederhergestellt, Test fiel, danach wieder grün).
- **`BrowserViewModel` ist auf ~340 Zeilen gewachsen** und reißt die 200-LOC-Grenze deutlicher als vorher (#126). Bewusst nicht in diesem PR aufgeräumt — der Schnitt gehört in einen eigenen Vorgang.
- **Altbefund, hier nicht angefasst:** die Android-Zurück-Geste verlässt die Demontage zur Übersicht, entgegen `workflow.md` US-003.6 („Beenden" ist der einzige Ausstieg). Der einzige `BackHandler` sitzt im Vollbild (`SchrittBrowser.kt:186`), nicht auf Ebene der Schritt-Ansicht.
- **`CLAUDE.md` nachgezogen:** der dort beschriebene F-002-Ist-Zustand (CameraX, `CAMERA`-Permission) existiert im Code nicht mehr — geprüft gegen `AndroidManifest.xml` und `libs.versions.toml`.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)